### PR TITLE
Redesign audit post-review menu options

### DIFF
--- a/src/zing_ai/commands/zing/build-audit.md
+++ b/src/zing_ai/commands/zing/build-audit.md
@@ -113,13 +113,13 @@ End your review summary with: "Zing! Review complete."
 After writing the review report, use AskUserQuestion to ask: "What next?"
 - Options:
   - "Create a PR" (description: "Create a GitHub PR from the current branch")
-  - "Fix the findings" (description: "Run /zing to plan and build fixes from the review report")
-  - "Discuss findings" (description: "Walk through each finding for a deeper conversation")
+  - "Fix with chat" (description: "Walk through each finding interactively — faster, fix as you go")
+  - "Build a plan to fix" (description: "Systematically plan and build a fix for each finding — slower but more thorough")
   - "I'm done" (description: "Stop here")
 
-If "Fix the findings": invoke the `Skill` tool with skill name `zing` and args set to the report file path (e.g. `.zing/code-review-feature-x-2025-06-15-1423.md`).
+If "Fix with chat": proceed to the `discuss_findings` step.
 
-If "Discuss findings": proceed to the `discuss_findings` step.
+If "Build a plan to fix": invoke the `Skill` tool with skill name `zing` and args set to the report file path (e.g. `.zing/code-review-feature-x-2025-06-15-1423.md`).
 
 If "Create a PR":
 1. Run `gh pr create --draft --fill` via Bash to create a draft PR (use --fill to auto-populate from commits)
@@ -153,7 +153,7 @@ Then enter a conversational loop. The user drives the interaction using natural 
 
 After each finding is resolved (fixed, skipped, or discussed), present the next one. Continue until all findings have been addressed or the user says done.
 
-After the walkthrough is complete, return to the `create_pr` step's AskUserQuestion — offer "Create a PR", "Fix the findings", and "I'm done" (without the "Discuss findings" option again).
+After the walkthrough is complete, return to the `create_pr` step's AskUserQuestion — offer "Create a PR", "Build a plan to fix", and "I'm done" (without the "Fix with chat" option again).
 </step>
 
 </process>

--- a/src/zing_ai/commands/zing/custom-audit.md
+++ b/src/zing_ai/commands/zing/custom-audit.md
@@ -241,13 +241,13 @@ End your review summary with: "Zing! Review complete."
 
 After writing the review report, use AskUserQuestion to ask: "What next?"
 - Options:
-  - "Fix the findings" (description: "Run /zing to plan and build fixes from the audit report")
-  - "Discuss findings" (description: "Walk through each finding for a deeper conversation")
+  - "Fix with chat" (description: "Walk through each finding interactively — faster, fix as you go")
+  - "Build a plan to fix" (description: "Systematically plan and build a fix for each finding — slower but more thorough")
   - "I'm done" (description: "Stop here")
 
-If "Fix the findings": invoke the `Skill` tool with skill name `zing` and args set to the report file path (e.g. `.zing/code-audit-auth-module-2025-06-15-1423.md`).
+If "Fix with chat": proceed to the `discuss_findings` step.
 
-If "Discuss findings": proceed to the `discuss_findings` step.
+If "Build a plan to fix": invoke the `Skill` tool with skill name `zing` and args set to the report file path (e.g. `.zing/code-audit-auth-module-2025-06-15-1423.md`).
 
 Follow the `attribution_rule` from the shared review reference.
 
@@ -273,7 +273,7 @@ Then enter a conversational loop. The user drives the interaction using natural 
 
 After each finding is resolved (fixed, skipped, or discussed), present the next one. Continue until all findings have been addressed or the user says done.
 
-After the walkthrough is complete, return to the `post_review` step's AskUserQuestion — offer "Fix the findings" and "I'm done" (without the "Discuss findings" option again).
+After the walkthrough is complete, return to the `post_review` step's AskUserQuestion — offer "Build a plan to fix" and "I'm done" (without the "Fix with chat" option again).
 </step>
 
 </process>


### PR DESCRIPTION
## Summary

- Swaps the two post-review fix options in audit skills so "Fix with chat" (interactive walkthrough, fix as you go) is the primary action and "Build a plan to fix" (systematic zing plan+build) is the slower alternative
- Applied consistently to both `build-audit.md` and `custom-audit.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)