### PR TITLE
Add launch command and link sessions to command center cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ The review commands use the MCP server and `curl` to coordinate agent workflows.
 uv tool install zing-ai
 ```
 
+### Install from a local checkout (editable)
+
+```
+uv tool install -e /path/to/Zing
+```
+
+Changes to the source take effect immediately without reinstalling.
+
 ### Install from GitHub
 
 **Bleeding edge** (latest features, may have rough edges):

--- a/src/zing_ai/cli.py
+++ b/src/zing_ai/cli.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import re
+import subprocess
 import sys
+import urllib.error
+import urllib.request
+import uuid
 from collections.abc import Callable
 from pathlib import Path
 
@@ -161,6 +168,254 @@ def mcp_cmd(port: int) -> None:
     click.echo(f"Starting Zing server on http://127.0.0.1:{port}")
     click.echo(f"Dashboard: http://127.0.0.1:{port}/dashboard")
     uvicorn.run(app, host="127.0.0.1", port=port, timeout_graceful_shutdown=3)
+
+
+_TICKET_RE = re.compile(r"^[A-Z]+-\d+$")
+
+
+@cli.command()
+@click.argument("target")  # ticket ID or PR URL
+@click.option("--resume/--no-resume", default=True, help="Auto-resume existing session if found")
+@click.option("--server-url", default="http://127.0.0.1:9876/mcp", help="Zing MCP server URL")
+def launch(target: str, resume: bool, server_url: str) -> None:
+    """Launch a Claude Code session for a ticket or PR."""
+    from zing_ai.config import ConfigError, load_config
+    from zing_ai.launch import (
+        LaunchError,
+        build_claude_args,
+        checkout_pr_branch,
+        create_mcp_session,
+        create_worktree,
+        derive_branch_name,
+        detect_action,
+        extract_ticket_id,
+        fetch_pr_data,
+        move_ticket_in_progress,
+        parse_pr_url,
+        resolve_repo_root,
+        rollback_worktree,
+        run_init_script,
+    )
+
+    try:
+        # Load config
+        try:
+            cfg = load_config()
+        except ConfigError as e:
+            click.echo(f"error: {e}", err=True)
+            sys.exit(1)
+
+        git_cfg = cfg.git
+        workflow_mode = git_cfg.workflow_mode
+
+        # Read Linear API key from ~/.config/lr/config.json
+        lr_config_path = Path.home() / ".config" / "lr" / "config.json"
+        try:
+            lr_config = json.loads(lr_config_path.read_text())
+            api_key = lr_config["workspaces"][lr_config["activeWorkspace"]]["apiKey"]
+        except (FileNotFoundError, KeyError, json.JSONDecodeError) as e:
+            raise LaunchError(f"Could not read Linear API key from {lr_config_path}: {e}") from e
+
+        # Check MCP server is running
+        check_req = urllib.request.Request(server_url, method="GET")
+        try:
+            urllib.request.urlopen(check_req)
+        except urllib.error.URLError as e:
+            raise LaunchError(
+                f"Zing MCP server is not running at {server_url}. Start it with 'zing-ai mcp'."
+            ) from e
+
+        # Detect target type: ticket ID or PR URL
+        is_ticket = bool(_TICKET_RE.match(target))
+
+        if is_ticket:
+            ticket_id = target
+
+            # Check for existing session
+            if resume:
+                action, existing_session_id = detect_action(ticket_id, server_url)
+            else:
+                action, existing_session_id = "new", None
+
+            if action == "resume" and existing_session_id is not None:
+                args = build_claude_args(
+                    skill="resume",
+                    ticket_id=ticket_id,
+                    session_id=existing_session_id,
+                    name=ticket_id,
+                )
+                os.execvp("claude", args)
+                return  # unreachable, but satisfies type checkers
+
+            # New ticket flow
+            repo_root = resolve_repo_root(Path.cwd())
+            branch_name = derive_branch_name(ticket_id, api_key)
+
+            # Handle workflow_mode
+            if workflow_mode == "ask":
+                workflow_mode = click.prompt(
+                    "Workflow mode",
+                    type=click.Choice(["worktree", "branch", "none"]),
+                    default="worktree",
+                )
+
+            session_id = str(uuid.uuid4())
+            worktree_path: Path | None = None
+
+            if workflow_mode == "worktree":
+                worktree_path = create_worktree(
+                    repo_root=repo_root,
+                    branch_name=branch_name,
+                    worktree_root_template=git_cfg.worktree_root,
+                    branch_prefix=git_cfg.branch_prefix,
+                )
+                work_dir = worktree_path
+            elif workflow_mode == "branch":
+                full_branch = f"{git_cfg.branch_prefix}{branch_name}"
+                try:
+                    subprocess.run(
+                        ["git", "checkout", "-b", full_branch],
+                        check=True,
+                        capture_output=True,
+                        text=True,
+                        cwd=Path.cwd(),
+                    )
+                except subprocess.CalledProcessError as exc:
+                    raise LaunchError(
+                        f"git checkout -b {full_branch} failed: {exc.stderr.strip()}"
+                    ) from exc
+                work_dir = Path.cwd()
+            else:
+                # workflow_mode == "none"
+                work_dir = Path.cwd()
+
+            # Subsequent steps — roll back worktree on failure
+            try:
+                run_init_script(
+                    repo_root=repo_root,
+                    script_name=git_cfg.zing_init_script,
+                    worktree_path=work_dir,
+                    branch=branch_name,
+                )
+            except LaunchError:
+                if worktree_path is not None:
+                    rollback_worktree(worktree_path)
+                raise
+
+            try:
+                move_ticket_in_progress(ticket_id, api_key)
+            except LaunchError:
+                if worktree_path is not None:
+                    rollback_worktree(worktree_path)
+                raise
+
+            try:
+                create_mcp_session(
+                    server_url=server_url,
+                    session_id=session_id,
+                    title=ticket_id,
+                    ticket_id=ticket_id,
+                    worktree_path=str(work_dir) if work_dir else None,
+                    skill="new",
+                )
+            except LaunchError:
+                if worktree_path is not None:
+                    rollback_worktree(worktree_path)
+                raise
+
+            args = build_claude_args(
+                skill="new",
+                ticket_id=ticket_id,
+                session_id=session_id,
+                name=ticket_id,
+            )
+            os.execvp("claude", args)
+
+        else:
+            # PR URL flow
+            owner, repo, pr_number = parse_pr_url(target)
+            pr_data = fetch_pr_data(owner, repo, pr_number)
+            branch_name = pr_data["headRefName"]
+            pr_title = pr_data.get("title", "")
+            pr_body = pr_data.get("body", "") or ""
+            ticket_id = extract_ticket_id(branch_name, pr_title, pr_body) or ""
+            pr_name = f"PR #{pr_number} Review"
+
+            repo_root = resolve_repo_root(Path.cwd())
+
+            # Handle workflow_mode
+            if workflow_mode == "ask":
+                workflow_mode = click.prompt(
+                    "Workflow mode",
+                    type=click.Choice(["worktree", "branch", "none"]),
+                    default="worktree",
+                )
+
+            session_id = str(uuid.uuid4())
+            worktree_path = None
+
+            if workflow_mode == "worktree":
+                worktree_path = checkout_pr_branch(
+                    repo_root=repo_root,
+                    branch_name=branch_name,
+                    worktree_root_template=git_cfg.worktree_root,
+                )
+                work_dir = worktree_path
+            elif workflow_mode == "branch":
+                try:
+                    subprocess.run(
+                        ["git", "checkout", branch_name],
+                        check=True,
+                        capture_output=True,
+                        text=True,
+                        cwd=Path.cwd(),
+                    )
+                except subprocess.CalledProcessError as exc:
+                    raise LaunchError(
+                        f"git checkout {branch_name} failed: {exc.stderr.strip()}"
+                    ) from exc
+                work_dir = Path.cwd()
+            else:
+                # workflow_mode == "none"
+                work_dir = Path.cwd()
+
+            try:
+                run_init_script(
+                    repo_root=repo_root,
+                    script_name=git_cfg.zing_init_script,
+                    worktree_path=work_dir,
+                    branch=branch_name,
+                )
+            except LaunchError:
+                if worktree_path is not None:
+                    rollback_worktree(worktree_path)
+                raise
+
+            try:
+                create_mcp_session(
+                    server_url=server_url,
+                    session_id=session_id,
+                    title=pr_name,
+                    ticket_id=ticket_id,
+                    worktree_path=str(work_dir) if work_dir else None,
+                    skill="pr-audit",
+                )
+            except LaunchError:
+                if worktree_path is not None:
+                    rollback_worktree(worktree_path)
+                raise
+
+            args = build_claude_args(
+                skill="pr-audit",
+                ticket_id=ticket_id,
+                session_id=session_id,
+                name=pr_name,
+            )
+            os.execvp("claude", args)
+
+    except LaunchError as e:
+        click.echo(str(e), err=True)
+        sys.exit(1)
 
 
 def _register_sim() -> None:

--- a/src/zing_ai/cli.py
+++ b/src/zing_ai/cli.py
@@ -177,7 +177,10 @@ _TICKET_RE = re.compile(r"^[A-Z]+-\d+$")
 @click.argument("target")  # ticket ID or PR URL
 @click.option("--resume/--no-resume", default=True, help="Auto-resume existing session if found")
 @click.option("--port", default=9876, type=int, help="Port the Zing server is listening on.")
-def launch(target: str, resume: bool, port: int) -> None:
+@click.option(
+    "--skill", default=None, type=str, help="Skill to use for the session (e.g. pr-respond)."
+)
+def launch(target: str, resume: bool, port: int, skill: str | None) -> None:
     """Launch a Claude Code session for a ticket or PR."""
     from zing_ai.config import ConfigError, load_config
     from zing_ai.launch import (
@@ -218,10 +221,12 @@ def launch(target: str, resume: bool, port: int) -> None:
         except (FileNotFoundError, KeyError, json.JSONDecodeError) as e:
             raise LaunchError(f"Could not read Linear API key from {lr_config_path}: {e}") from e
 
-        # Check server is running
+        # Check server is running (any HTTP response means it's up)
         check_req = urllib.request.Request(server_url, method="GET")
         try:
             urllib.request.urlopen(check_req)
+        except urllib.error.HTTPError:
+            pass  # Server is running, just returned a non-2xx status
         except urllib.error.URLError as e:
             raise LaunchError(
                 f"Zing server is not running at {server_url}. Start it with 'zing-ai mcp'."
@@ -242,7 +247,6 @@ def launch(target: str, resume: bool, port: int) -> None:
             if action == "resume" and existing_session_id is not None:
                 args = build_claude_args(
                     skill="resume",
-                    ticket_id=ticket_id,
                     session_id=existing_session_id,
                     name=ticket_id,
                 )
@@ -315,20 +319,22 @@ def launch(target: str, resume: bool, port: int) -> None:
 
             args = build_claude_args(
                 skill="new",
-                ticket_id=ticket_id,
                 session_id=session_id,
                 name=ticket_id,
+                target=ticket_id,
             )
+            os.chdir(work_dir)
             os.execvp("claude", args)
 
         else:
             # PR URL flow
+            pr_skill = skill or "pr-audit"
             owner, repo, pr_number = parse_pr_url(target)
             pr_data = fetch_pr_data(owner, repo, pr_number)
             branch_name = pr_data["headRefName"]
             pr_title = pr_data.get("title", "")
             pr_body = pr_data.get("body", "") or ""
-            ticket_id = extract_ticket_id(branch_name, pr_title, pr_body) or ""
+            ticket_id = extract_ticket_id(branch_name, pr_title, pr_body)
             pr_name = f"PR #{pr_number} Review"
 
             repo_root = resolve_repo_root(Path.cwd())
@@ -383,7 +389,9 @@ def launch(target: str, resume: bool, port: int) -> None:
                     title=pr_name,
                     ticket_id=ticket_id,
                     worktree_path=str(work_dir) if work_dir else None,
-                    skill="pr-audit",
+                    skill=pr_skill,
+                    pr_number=pr_number,
+                    pr_repo=f"{owner}/{repo}",
                 )
                 succeeded = True
             finally:
@@ -391,11 +399,12 @@ def launch(target: str, resume: bool, port: int) -> None:
                     rollback_worktree(worktree_path)
 
             args = build_claude_args(
-                skill="pr-audit",
-                ticket_id=ticket_id,
+                skill=pr_skill,
                 session_id=session_id,
                 name=pr_name,
+                target=target,
             )
+            os.chdir(work_dir)
             os.execvp("claude", args)
 
     except LaunchError as e:

--- a/src/zing_ai/cli.py
+++ b/src/zing_ai/cli.py
@@ -170,9 +170,6 @@ def mcp_cmd(port: int) -> None:
     uvicorn.run(app, host="127.0.0.1", port=port, timeout_graceful_shutdown=3)
 
 
-_TICKET_RE = re.compile(r"^[A-Z]+-\d+$")
-
-
 @cli.command()
 @click.argument("target")  # ticket ID or PR URL
 @click.option("--resume/--no-resume", default=True, help="Auto-resume existing session if found")
@@ -184,6 +181,7 @@ def launch(target: str, resume: bool, port: int, skill: str | None) -> None:
     """Launch a Claude Code session for a ticket or PR."""
     from zing_ai.config import ConfigError, load_config
     from zing_ai.launch import (
+        TICKET_ID_PATTERN,
         LaunchError,
         build_claude_args,
         checkout_pr_branch,
@@ -213,14 +211,6 @@ def launch(target: str, resume: bool, port: int, skill: str | None) -> None:
         git_cfg = cfg.git
         workflow_mode = git_cfg.workflow_mode
 
-        # Read Linear API key from ~/.config/lr/config.json
-        lr_config_path = Path.home() / ".config" / "lr" / "config.json"
-        try:
-            lr_config = json.loads(lr_config_path.read_text())
-            api_key = lr_config["workspaces"][lr_config["activeWorkspace"]]["apiKey"]
-        except (FileNotFoundError, KeyError, json.JSONDecodeError) as e:
-            raise LaunchError(f"Could not read Linear API key from {lr_config_path}: {e}") from e
-
         # Check server is running (any HTTP response means it's up)
         check_req = urllib.request.Request(server_url, method="GET")
         try:
@@ -233,7 +223,7 @@ def launch(target: str, resume: bool, port: int, skill: str | None) -> None:
             ) from e
 
         # Detect target type: ticket ID or PR URL
-        is_ticket = bool(_TICKET_RE.match(target))
+        is_ticket = bool(re.match(rf"^{TICKET_ID_PATTERN}$", target))
 
         if is_ticket:
             ticket_id = target
@@ -253,7 +243,16 @@ def launch(target: str, resume: bool, port: int, skill: str | None) -> None:
                 os.execvp("claude", args)
                 return  # unreachable, but satisfies type checkers
 
-            # New ticket flow
+            # New ticket flow — read Linear API key (only needed for tickets)
+            lr_config_path = Path.home() / ".config" / "lr" / "config.json"
+            try:
+                lr_config = json.loads(lr_config_path.read_text())
+                api_key = lr_config["workspaces"][lr_config["activeWorkspace"]]["apiKey"]
+            except (FileNotFoundError, KeyError, json.JSONDecodeError) as e:
+                raise LaunchError(
+                    f"Could not read Linear API key from {lr_config_path}: {e}"
+                ) from e
+
             repo_root = resolve_repo_root(Path.cwd())
             branch_name = derive_branch_name(ticket_id, api_key)
 

--- a/src/zing_ai/cli.py
+++ b/src/zing_ai/cli.py
@@ -176,15 +176,15 @@ _TICKET_RE = re.compile(r"^[A-Z]+-\d+$")
 @cli.command()
 @click.argument("target")  # ticket ID or PR URL
 @click.option("--resume/--no-resume", default=True, help="Auto-resume existing session if found")
-@click.option("--server-url", default="http://127.0.0.1:9876/mcp", help="Zing MCP server URL")
-def launch(target: str, resume: bool, server_url: str) -> None:
+@click.option("--port", default=9876, type=int, help="Port the Zing server is listening on.")
+def launch(target: str, resume: bool, port: int) -> None:
     """Launch a Claude Code session for a ticket or PR."""
     from zing_ai.config import ConfigError, load_config
     from zing_ai.launch import (
         LaunchError,
         build_claude_args,
         checkout_pr_branch,
-        create_mcp_session,
+        create_session_on_server,
         create_worktree,
         derive_branch_name,
         detect_action,
@@ -196,6 +196,8 @@ def launch(target: str, resume: bool, server_url: str) -> None:
         rollback_worktree,
         run_init_script,
     )
+
+    server_url = f"http://127.0.0.1:{port}"
 
     try:
         # Load config
@@ -216,13 +218,13 @@ def launch(target: str, resume: bool, server_url: str) -> None:
         except (FileNotFoundError, KeyError, json.JSONDecodeError) as e:
             raise LaunchError(f"Could not read Linear API key from {lr_config_path}: {e}") from e
 
-        # Check MCP server is running
+        # Check server is running
         check_req = urllib.request.Request(server_url, method="GET")
         try:
             urllib.request.urlopen(check_req)
         except urllib.error.URLError as e:
             raise LaunchError(
-                f"Zing MCP server is not running at {server_url}. Start it with 'zing-ai mcp'."
+                f"Zing server is not running at {server_url}. Start it with 'zing-ai mcp'."
             ) from e
 
         # Detect target type: ticket ID or PR URL
@@ -289,7 +291,7 @@ def launch(target: str, resume: bool, server_url: str) -> None:
                 # workflow_mode == "none"
                 work_dir = Path.cwd()
 
-            # Subsequent steps — roll back worktree on failure
+            succeeded = False
             try:
                 run_init_script(
                     repo_root=repo_root,
@@ -297,20 +299,8 @@ def launch(target: str, resume: bool, server_url: str) -> None:
                     worktree_path=work_dir,
                     branch=branch_name,
                 )
-            except LaunchError:
-                if worktree_path is not None:
-                    rollback_worktree(worktree_path)
-                raise
-
-            try:
                 move_ticket_in_progress(ticket_id, api_key)
-            except LaunchError:
-                if worktree_path is not None:
-                    rollback_worktree(worktree_path)
-                raise
-
-            try:
-                create_mcp_session(
+                create_session_on_server(
                     server_url=server_url,
                     session_id=session_id,
                     title=ticket_id,
@@ -318,10 +308,10 @@ def launch(target: str, resume: bool, server_url: str) -> None:
                     worktree_path=str(work_dir) if work_dir else None,
                     skill="new",
                 )
-            except LaunchError:
-                if worktree_path is not None:
+                succeeded = True
+            finally:
+                if not succeeded and worktree_path is not None:
                     rollback_worktree(worktree_path)
-                raise
 
             args = build_claude_args(
                 skill="new",
@@ -379,6 +369,7 @@ def launch(target: str, resume: bool, server_url: str) -> None:
                 # workflow_mode == "none"
                 work_dir = Path.cwd()
 
+            succeeded = False
             try:
                 run_init_script(
                     repo_root=repo_root,
@@ -386,13 +377,7 @@ def launch(target: str, resume: bool, server_url: str) -> None:
                     worktree_path=work_dir,
                     branch=branch_name,
                 )
-            except LaunchError:
-                if worktree_path is not None:
-                    rollback_worktree(worktree_path)
-                raise
-
-            try:
-                create_mcp_session(
+                create_session_on_server(
                     server_url=server_url,
                     session_id=session_id,
                     title=pr_name,
@@ -400,10 +385,10 @@ def launch(target: str, resume: bool, server_url: str) -> None:
                     worktree_path=str(work_dir) if work_dir else None,
                     skill="pr-audit",
                 )
-            except LaunchError:
-                if worktree_path is not None:
+                succeeded = True
+            finally:
+                if not succeeded and worktree_path is not None:
                     rollback_worktree(worktree_path)
-                raise
 
             args = build_claude_args(
                 skill="pr-audit",

--- a/src/zing_ai/launch.py
+++ b/src/zing_ai/launch.py
@@ -16,8 +16,11 @@ from __future__ import annotations
 
 import json
 import os
+import re
+import shutil
 import subprocess
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Literal
@@ -25,6 +28,111 @@ from typing import Literal
 
 class LaunchError(Exception):
     """Raised when any launch step fails.  The CLI command catches this and exits non-zero."""
+
+
+# ---------------------------------------------------------------------------
+# Ticket ID regex (same pattern as command_center.py)
+# ---------------------------------------------------------------------------
+
+_TICKET_RE = re.compile(r"\b[A-Z]{2,}-\d+\b")
+
+# ---------------------------------------------------------------------------
+# PR URL helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_pr_url(url: str) -> tuple[str, str, int]:
+    """Parse a GitHub pull-request URL and return (owner, repo, number).
+
+    Accepts:
+    - ``https://github.com/{owner}/{repo}/pull/{number}``
+    - ``https://github.com/{owner}/{repo}/pull/{number}/...`` (with trailing segments)
+
+    Args:
+        url: GitHub PR URL string.
+
+    Returns:
+        A ``(owner, repo, number)`` tuple.
+
+    Raises:
+        LaunchError: If the URL is not a recognised GitHub PR URL.
+    """
+    parsed = urllib.parse.urlparse(url)
+    match = re.match(r"^/([^/]+)/([^/]+)/pull/(\d+)", parsed.path)
+    if not match:
+        raise LaunchError(f"Not a valid GitHub PR URL: {url!r}")
+    owner, repo, number_str = match.group(1), match.group(2), match.group(3)
+    return owner, repo, int(number_str)
+
+
+def fetch_pr_data(owner: str, repo: str, number: int) -> dict:
+    """Fetch PR metadata from GitHub using the ``gh`` CLI.
+
+    Runs ``gh pr view <number> --repo <owner>/<repo> --json headRefName,title,body``
+    and returns the parsed JSON dict.
+
+    Args:
+        owner: Repository owner (user or org).
+        repo: Repository name.
+        number: Pull-request number.
+
+    Returns:
+        Parsed JSON dict with keys ``headRefName``, ``title``, and ``body``.
+
+    Raises:
+        LaunchError: If ``gh`` is not on PATH or the command fails.
+    """
+    if shutil.which("gh") is None:
+        raise LaunchError(
+            "GitHub CLI (gh) is required for PR-based launches."
+            " Install it from https://cli.github.com/"
+        )
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(number),
+                "--repo",
+                f"{owner}/{repo}",
+                "--json",
+                "headRefName,title,body",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise LaunchError(
+            f"gh pr view failed for {owner}/{repo}#{number}: {exc.stderr.strip()}"
+        ) from exc
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise LaunchError(f"gh pr view returned non-JSON output: {exc}") from exc
+
+
+def extract_ticket_id(branch: str, title: str, body: str) -> str | None:
+    """Search *branch*, *title*, and *body* for a Linear ticket ID.
+
+    Uses the ``_TICKET_RE`` pattern (``r"\\b[A-Z]{2,}-\\d+\\b"``) and returns
+    the first match found, checked in the order: branch → title → body.
+
+    Args:
+        branch: PR head branch name.
+        title: PR title.
+        body: PR body / description.
+
+    Returns:
+        Uppercased ticket ID string (e.g. ``"BAK-123"``), or ``None`` if not found.
+    """
+    for text in (branch, title, body):
+        if text:
+            match = _TICKET_RE.search(text)
+            if match:
+                return match.group(0).upper()
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/src/zing_ai/launch.py
+++ b/src/zing_ai/launch.py
@@ -1,0 +1,558 @@
+"""Core launch logic for `zing-ai launch` — worktree creation, init scripts, Linear updates.
+
+All functions are pure (no Click dependency) so they can be unit-tested with mocked subprocess
+calls.  The CLI command in cli.py imports and orchestrates these functions.
+
+Workflow mode notes
+-------------------
+- ``"worktree"``: call :func:`create_worktree`.
+- ``"branch"``: run ``git checkout -b <prefix><branch>`` in the current repo, return ``cwd``.
+- ``"none"``: return ``cwd`` unchanged.
+- ``"ask"``: the **caller** (CLI command) must prompt the user and then dispatch to one of the
+  modes above.  This module does not import Click and will not prompt.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Literal
+
+
+class LaunchError(Exception):
+    """Raised when any launch step fails.  The CLI command catches this and exits non-zero."""
+
+
+# ---------------------------------------------------------------------------
+# Git helpers
+# ---------------------------------------------------------------------------
+
+
+def resolve_repo_root(cwd: Path) -> Path:
+    """Return the main git repository root, resolving through worktrees.
+
+    Runs ``git rev-parse --show-toplevel`` to get the current root, then
+    ``git worktree list --porcelain`` to check whether that root is a linked
+    worktree.  If so, returns the main worktree's root instead.
+
+    Args:
+        cwd: Directory to run git commands from.
+
+    Returns:
+        Absolute path to the main worktree root.
+
+    Raises:
+        LaunchError: If any git command fails.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+        )
+        current_root = Path(result.stdout.strip())
+    except subprocess.CalledProcessError as exc:
+        raise LaunchError(f"git rev-parse failed: {exc.stderr.strip()}") from exc
+
+    # Parse worktree list to find the main worktree root.
+    try:
+        wt_result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise LaunchError(f"git worktree list failed: {exc.stderr.strip()}") from exc
+
+    # The first worktree entry (no "worktree" key mismatch with "bare" or branch) is the main one.
+    # Porcelain format: blocks separated by blank lines, first field is "worktree <path>".
+    main_root: Path | None = None
+    for block in wt_result.stdout.split("\n\n"):
+        lines = [ln for ln in block.strip().splitlines() if ln]
+        if not lines:
+            continue
+        path_line = lines[0]
+        if not path_line.startswith("worktree "):
+            continue
+        wt_path = Path(path_line[len("worktree ") :].strip())
+        # The main worktree never has an "isbare" marker but also won't have a "branch" line
+        # containing "refs/heads/..." pointing elsewhere — simplest heuristic: first entry is main.
+        if main_root is None:
+            main_root = wt_path
+        # If current_root matches a linked worktree (not the first one), use main_root.
+        if wt_path == current_root and main_root != current_root:
+            return main_root
+
+    # Either not in a worktree, or is already the main worktree.
+    return current_root
+
+
+def create_worktree(
+    repo_root: Path,
+    branch_name: str,
+    worktree_root_template: str,
+    branch_prefix: str,
+) -> Path:
+    """Create a new git worktree on a new branch.
+
+    The worktree path is derived by formatting *worktree_root_template* with:
+
+    - ``{repo}`` — basename of *repo_root*
+    - ``{branch}`` — *branch_name*
+
+    Runs ``git worktree add -b <prefix><branch> <path>`` from *repo_root*.
+
+    Args:
+        repo_root: Absolute path to the main repository root.
+        branch_name: Branch slug (without prefix).
+        worktree_root_template: Template string, e.g. ``"../{repo}-{branch}"``.
+        branch_prefix: Prefix prepended to the branch name, e.g. ``"zing/"``.
+
+    Returns:
+        Absolute path to the newly-created worktree directory.
+
+    Raises:
+        LaunchError: If ``git worktree add`` fails.
+    """
+    repo_name = repo_root.name
+    relative = worktree_root_template.format(repo=repo_name, branch=branch_name)
+    worktree_path = (repo_root / relative).resolve()
+    full_branch = f"{branch_prefix}{branch_name}"
+
+    try:
+        subprocess.run(
+            ["git", "worktree", "add", "-b", full_branch, str(worktree_path)],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise LaunchError(f"git worktree add failed: {exc.stderr.strip()}") from exc
+
+    return worktree_path
+
+
+def checkout_pr_branch(
+    repo_root: Path,
+    branch_name: str,
+    worktree_root_template: str,
+) -> Path:
+    """Create a new git worktree on an existing (remote) branch.
+
+    Runs ``git worktree add <path> <branch>`` — no ``-b`` flag, so the branch
+    must already exist (e.g. a PR branch fetched from origin).
+
+    Args:
+        repo_root: Absolute path to the main repository root.
+        branch_name: Existing branch name.
+        worktree_root_template: Template string, e.g. ``"../{repo}-{branch}"``.
+
+    Returns:
+        Absolute path to the newly-created worktree directory.
+
+    Raises:
+        LaunchError: If ``git worktree add`` fails.
+    """
+    repo_name = repo_root.name
+    relative = worktree_root_template.format(repo=repo_name, branch=branch_name)
+    worktree_path = (repo_root / relative).resolve()
+
+    try:
+        subprocess.run(
+            ["git", "worktree", "add", str(worktree_path), branch_name],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise LaunchError(f"git worktree add failed: {exc.stderr.strip()}") from exc
+
+    return worktree_path
+
+
+def rollback_worktree(worktree_path: Path) -> None:
+    """Remove a worktree forcefully.  Called on downstream failure after creation.
+
+    Runs ``git worktree remove --force <path>``.
+
+    Args:
+        worktree_path: Absolute path to the worktree to remove.
+
+    Raises:
+        LaunchError: If ``git worktree remove`` fails.
+    """
+    try:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(worktree_path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise LaunchError(f"git worktree remove failed: {exc.stderr.strip()}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Init script
+# ---------------------------------------------------------------------------
+
+
+def run_init_script(
+    repo_root: Path,
+    script_name: str,
+    worktree_path: Path,
+    branch: str,
+) -> None:
+    """Run the repository's init script inside the worktree directory, if present.
+
+    Looks for ``<repo_root>/<script_name>``.  If the file exists, runs it as a
+    subprocess from *worktree_path* with the following environment variables:
+
+    - ``ZING_BRANCH`` — *branch*
+    - ``ZING_WORKTREE_PATH`` — absolute string of *worktree_path*
+    - ``ZING_SPEC_FILE`` — empty string
+    - ``ZING_SESSION_ID`` — empty string
+
+    Args:
+        repo_root: Absolute path to the main repository root (where the script lives).
+        script_name: Filename of the init script, e.g. ``".zing-init.sh"``.
+        worktree_path: Directory to run the script from.
+        branch: Branch name passed as ``ZING_BRANCH``.
+
+    Raises:
+        LaunchError: If the script exits with a non-zero status.
+    """
+    script_path = repo_root / script_name
+    if not script_path.exists():
+        return
+
+    env = {**os.environ}
+    env["ZING_BRANCH"] = branch
+    env["ZING_WORKTREE_PATH"] = str(worktree_path)
+    env["ZING_SPEC_FILE"] = ""
+    env["ZING_SESSION_ID"] = ""
+
+    try:
+        subprocess.run(
+            [str(script_path)],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=worktree_path,
+            env=env,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise LaunchError(
+            f"Init script {script_name} exited with code {exc.returncode}: {exc.stderr.strip()}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Linear helpers
+# ---------------------------------------------------------------------------
+
+
+def _linear_request(api_key: str, query: str, variables: dict | None = None) -> dict:
+    """Execute a Linear GraphQL request and return the parsed JSON response.
+
+    Args:
+        api_key: Linear API key.
+        query: GraphQL query or mutation string.
+        variables: Optional variables dict.
+
+    Returns:
+        Parsed JSON response dict (the full response, not just ``data``).
+
+    Raises:
+        LaunchError: On HTTP errors or non-JSON responses.
+    """
+    payload: dict = {"query": query}
+    if variables:
+        payload["variables"] = variables
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        "https://api.linear.app/graphql",
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": api_key,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        raise LaunchError(f"Linear API HTTP {exc.code}: {exc.reason}") from exc
+    except urllib.error.URLError as exc:
+        raise LaunchError(f"Linear API request failed: {exc.reason}") from exc
+    except json.JSONDecodeError as exc:
+        raise LaunchError(f"Linear API returned non-JSON response: {exc}") from exc
+
+
+def derive_branch_name(ticket_id: str, api_key: str) -> str:
+    """Fetch the suggested branch name for a Linear issue.
+
+    Calls ``{ issue(id: "<ticket_id>") { branchName } }`` via the Linear GraphQL
+    API and returns the ``branchName`` string.
+
+    Args:
+        ticket_id: Linear issue identifier, e.g. ``"BAK-123"``.
+        api_key: Linear API key.
+
+    Returns:
+        The ``branchName`` string from Linear.
+
+    Raises:
+        LaunchError: If the API call fails or the issue is not found.
+    """
+    query = f'{{ issue(id: "{ticket_id}") {{ branchName }} }}'
+    resp = _linear_request(api_key, query)
+    try:
+        branch_name = resp["data"]["issue"]["branchName"]
+    except (KeyError, TypeError) as exc:
+        raise LaunchError(f"Could not retrieve branchName for {ticket_id}: {resp}") from exc
+    if not branch_name:
+        raise LaunchError(f"Linear returned empty branchName for {ticket_id}")
+    return branch_name
+
+
+def move_ticket_in_progress(ticket_id: str, api_key: str) -> None:
+    """Move a Linear ticket to the "In Progress" workflow state.
+
+    Makes three GraphQL calls:
+
+    1. Fetch the team ID for the issue.
+    2. Fetch the "In Progress" workflow state ID for that team.
+    3. Update the issue's ``stateId``.
+
+    Args:
+        ticket_id: Linear issue identifier, e.g. ``"BAK-123"``.
+        api_key: Linear API key.
+
+    Raises:
+        LaunchError: If any API call fails or required data is missing.
+    """
+    # Step 1: fetch team id
+    team_query = f'{{ issue(id: "{ticket_id}") {{ id team {{ id }} }} }}'
+    team_resp = _linear_request(api_key, team_query)
+    try:
+        issue_data = team_resp["data"]["issue"]
+        issue_id = issue_data["id"]
+        team_id = issue_data["team"]["id"]
+    except (KeyError, TypeError) as exc:
+        raise LaunchError(f"Could not retrieve team for {ticket_id}: {team_resp}") from exc
+
+    # Step 2: fetch "In Progress" state id
+    state_query = f"""
+    {{
+      workflowStates(filter: {{
+        team: {{ id: {{ eq: "{team_id}" }} }},
+        name: {{ eq: "In Progress" }}
+      }}) {{
+        nodes {{ id }}
+      }}
+    }}
+    """
+    state_resp = _linear_request(api_key, state_query)
+    try:
+        nodes = state_resp["data"]["workflowStates"]["nodes"]
+        state_id = nodes[0]["id"]
+    except (KeyError, TypeError, IndexError) as exc:
+        raise LaunchError(
+            f"Could not find 'In Progress' state for team {team_id}: {state_resp}"
+        ) from exc
+
+    # Step 3: update issue
+    mutation = f"""
+    mutation {{
+      issueUpdate(id: "{issue_id}", input: {{ stateId: "{state_id}" }}) {{
+        success
+      }}
+    }}
+    """
+    update_resp = _linear_request(api_key, mutation)
+    try:
+        success = update_resp["data"]["issueUpdate"]["success"]
+    except (KeyError, TypeError) as exc:
+        raise LaunchError(f"issueUpdate returned unexpected response: {update_resp}") from exc
+    if not success:
+        raise LaunchError(f"issueUpdate returned success=false for {ticket_id}")
+
+
+# ---------------------------------------------------------------------------
+# MCP session helpers
+# ---------------------------------------------------------------------------
+
+
+def _call_mcp_http(server_url: str, tool_name: str, arguments: dict) -> dict:
+    """Call an MCP tool via a plain HTTP POST (JSON-RPC 2.0 style).
+
+    This mirrors the pattern used in ``sim.py``'s ``_call_mcp()`` but uses
+    ``urllib.request`` so the function has no extra dependencies.
+
+    Args:
+        server_url: Base URL of the MCP server, e.g. ``"http://localhost:9876/mcp"``.
+        tool_name: Name of the MCP tool to invoke.
+        arguments: Tool arguments dict.
+
+    Returns:
+        Parsed response dict.
+
+    Raises:
+        LaunchError: On HTTP errors, connection failures, or non-JSON responses.
+    """
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": tool_name,
+            "arguments": arguments,
+        },
+    }
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        server_url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        raise LaunchError(f"MCP server HTTP {exc.code}: {exc.reason}") from exc
+    except (urllib.error.URLError, ConnectionRefusedError, OSError) as exc:
+        raise LaunchError(
+            f"Could not connect to Zing MCP server at {server_url}. Is 'zing-ai mcp' running?"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise LaunchError(f"MCP server returned non-JSON response: {exc}") from exc
+
+
+def create_mcp_session(
+    server_url: str,
+    session_id: str,
+    title: str,
+    ticket_id: str,
+    worktree_path: str | None,
+    skill: str | None,
+) -> None:
+    """Create a ``ClaudeCodeSession`` on the MCP server.
+
+    Args:
+        server_url: MCP server URL.
+        session_id: Unique session identifier.
+        title: Human-readable session title.
+        ticket_id: Linear ticket ID associated with this session.
+        worktree_path: Absolute path of the worktree, or ``None``.
+        skill: Skill/command name, or ``None``.
+
+    Raises:
+        LaunchError: If the MCP call fails.
+    """
+    arguments: dict = {
+        "session_id": session_id,
+        "title": title,
+        "ticket_id": ticket_id,
+        "type": "ClaudeCodeSession",
+    }
+    if worktree_path is not None:
+        arguments["worktree_path"] = worktree_path
+    if skill is not None:
+        arguments["skill"] = skill
+
+    _call_mcp_http(server_url, "session_create", arguments)
+
+
+def detect_action(
+    ticket_id: str,
+    server_url: str,
+) -> tuple[Literal["resume", "new"], str | None]:
+    """Check whether an existing Claude Code session exists for *ticket_id*.
+
+    Calls the MCP server to list sessions and finds any ``ClaudeCodeSession``
+    with a matching ``ticket_id``.
+
+    Args:
+        ticket_id: Linear ticket ID to look for.
+        server_url: MCP server URL.
+
+    Returns:
+        ``("resume", session_id)`` if a matching session is found, otherwise
+        ``("new", None)``.
+
+    Raises:
+        LaunchError: If the MCP call fails.
+    """
+    resp = _call_mcp_http(server_url, "session_list", {})
+    # Response may be a JSON-RPC result wrapping the list, or the list directly.
+    sessions: list[dict] = []
+    if isinstance(resp, list):
+        sessions = resp
+    elif isinstance(resp, dict):
+        # JSON-RPC 2.0 envelope
+        result = resp.get("result", resp)
+        if isinstance(result, list):
+            sessions = result
+        elif isinstance(result, dict):
+            sessions = result.get("sessions", [])
+
+    for session in sessions:
+        if session.get("type") == "ClaudeCodeSession" and session.get("ticket_id") == ticket_id:
+            return ("resume", session["session_id"])
+
+    return ("new", None)
+
+
+# ---------------------------------------------------------------------------
+# Claude argument builder
+# ---------------------------------------------------------------------------
+
+
+def build_claude_args(
+    skill: str,
+    ticket_id: str | None,
+    session_id: str,
+    name: str,
+) -> list[str]:
+    """Build the argv list to pass to ``os.execvp("claude", ...)`` .
+
+    Three modes are supported:
+
+    - ``skill == "resume"``: ``["claude", "--resume", session_id]``
+    - ``skill == "pr-audit"``: ``["claude", "/zing:pr-audit", "--session-id", session_id,
+      "--name", name]``
+    - anything else (e.g. ``"new"``): ``["claude", "/zing:new <ticket_id>", "--session-id",
+      session_id, "--name", name]``
+
+    Args:
+        skill: One of ``"resume"``, ``"pr-audit"``, or a new-session skill (e.g. ``"new"``).
+        ticket_id: Linear ticket ID, used in the new-session slash command.  May be ``None``
+            for resume/pr-audit flows.
+        session_id: Claude session identifier.
+        name: Session display name.
+
+    Returns:
+        List of strings suitable for ``os.execvp``.
+    """
+    if skill == "resume":
+        return ["claude", "--resume", session_id]
+
+    if skill == "pr-audit":
+        return ["claude", "/zing:pr-audit", "--session-id", session_id, "--name", name]
+
+    # Default: new ticket session
+    slash_cmd = f"/zing:new {ticket_id}" if ticket_id else "/zing:new"
+    return ["claude", slash_cmd, "--session-id", session_id, "--name", name]

--- a/src/zing_ai/launch.py
+++ b/src/zing_ai/launch.py
@@ -411,8 +411,8 @@ def _linear_request(api_key: str, query: str, variables: dict | None = None) -> 
 def derive_branch_name(ticket_id: str, api_key: str) -> str:
     """Fetch the suggested branch name for a Linear issue.
 
-    Calls ``{ issue(id: "<ticket_id>") { branchName } }`` via the Linear GraphQL
-    API and returns the ``branchName`` string.
+    Calls ``{ issue(id: $id) { branchName } }`` via the Linear GraphQL API
+    and returns the ``branchName`` string.
 
     Args:
         ticket_id: Linear issue identifier, e.g. ``"BAK-123"``.
@@ -424,8 +424,8 @@ def derive_branch_name(ticket_id: str, api_key: str) -> str:
     Raises:
         LaunchError: If the API call fails or the issue is not found.
     """
-    query = f'{{ issue(id: "{ticket_id}") {{ branchName }} }}'
-    resp = _linear_request(api_key, query)
+    query = "query($id: String!) { issue(id: $id) { branchName } }"
+    resp = _linear_request(api_key, query, variables={"id": ticket_id})
     try:
         branch_name = resp["data"]["issue"]["branchName"]
     except (KeyError, TypeError) as exc:
@@ -452,8 +452,8 @@ def move_ticket_in_progress(ticket_id: str, api_key: str) -> None:
         LaunchError: If any API call fails or required data is missing.
     """
     # Step 1: fetch team id
-    team_query = f'{{ issue(id: "{ticket_id}") {{ id team {{ id }} }} }}'
-    team_resp = _linear_request(api_key, team_query)
+    team_query = "query($id: String!) { issue(id: $id) { id team { id } } }"
+    team_resp = _linear_request(api_key, team_query, variables={"id": ticket_id})
     try:
         issue_data = team_resp["data"]["issue"]
         issue_id = issue_data["id"]
@@ -462,17 +462,21 @@ def move_ticket_in_progress(ticket_id: str, api_key: str) -> None:
         raise LaunchError(f"Could not retrieve team for {ticket_id}: {team_resp}") from exc
 
     # Step 2: fetch "In Progress" state id
-    state_query = f"""
-    {{
-      workflowStates(filter: {{
-        team: {{ id: {{ eq: "{team_id}" }} }},
-        name: {{ eq: "In Progress" }}
-      }}) {{
-        nodes {{ id }}
-      }}
-    }}
+    state_query = """
+    query($teamId: ID!, $name: String!) {
+      workflowStates(filter: {
+        team: { id: { eq: $teamId } },
+        name: { eq: $name }
+      }) {
+        nodes { id }
+      }
+    }
     """
-    state_resp = _linear_request(api_key, state_query)
+    state_resp = _linear_request(
+        api_key,
+        state_query,
+        variables={"teamId": team_id, "name": "In Progress"},
+    )
     try:
         nodes = state_resp["data"]["workflowStates"]["nodes"]
         state_id = nodes[0]["id"]
@@ -482,14 +486,18 @@ def move_ticket_in_progress(ticket_id: str, api_key: str) -> None:
         ) from exc
 
     # Step 3: update issue
-    mutation = f"""
-    mutation {{
-      issueUpdate(id: "{issue_id}", input: {{ stateId: "{state_id}" }}) {{
+    mutation = """
+    mutation($issueId: String!, $stateId: String!) {
+      issueUpdate(id: $issueId, input: { stateId: $stateId }) {
         success
-      }}
-    }}
+      }
+    }
     """
-    update_resp = _linear_request(api_key, mutation)
+    update_resp = _linear_request(
+        api_key,
+        mutation,
+        variables={"issueId": issue_id, "stateId": state_id},
+    )
     try:
         success = update_resp["data"]["issueUpdate"]["success"]
     except (KeyError, TypeError) as exc:
@@ -503,85 +511,53 @@ def move_ticket_in_progress(ticket_id: str, api_key: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _call_mcp_http(server_url: str, tool_name: str, arguments: dict) -> dict:
-    """Call an MCP tool via a plain HTTP POST (JSON-RPC 2.0 style).
+def create_session_on_server(
+    server_url: str,
+    session_id: str,
+    title: str,
+    ticket_id: str | None,
+    worktree_path: str | None,
+    skill: str | None,
+) -> None:
+    """Create a ``ClaudeCodeSession`` on the Zing server via REST.
 
-    This mirrors the pattern used in ``sim.py``'s ``_call_mcp()`` but uses
-    ``urllib.request`` so the function has no extra dependencies.
+    Makes a plain ``POST /api/sessions/claude-code`` with a JSON body — no
+    JSON-RPC envelope.
 
     Args:
-        server_url: Base URL of the MCP server, e.g. ``"http://localhost:9876/mcp"``.
-        tool_name: Name of the MCP tool to invoke.
-        arguments: Tool arguments dict.
-
-    Returns:
-        Parsed response dict.
+        server_url: Base URL of the Zing server, e.g. ``"http://127.0.0.1:9876"``.
+        session_id: Unique session identifier.
+        title: Human-readable session title.
+        ticket_id: Linear ticket ID, or ``None``.
+        worktree_path: Absolute worktree path, or ``None``.
+        skill: Skill/command name, or ``None``.
 
     Raises:
-        LaunchError: On HTTP errors, connection failures, or non-JSON responses.
+        LaunchError: If the HTTP call fails.
     """
-    payload = {
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "tools/call",
-        "params": {
-            "name": tool_name,
-            "arguments": arguments,
-        },
+    payload: dict = {
+        "session_id": session_id,
+        "title": title,
+        "ticket_id": ticket_id,
+        "worktree_path": worktree_path,
+        "skill": skill,
     }
     body = json.dumps(payload).encode()
     req = urllib.request.Request(
-        server_url,
+        f"{server_url.rstrip('/')}/api/sessions/claude-code",
         data=body,
         headers={"Content-Type": "application/json"},
         method="POST",
     )
     try:
         with urllib.request.urlopen(req) as resp:
-            return json.loads(resp.read().decode())
+            resp.read()
     except urllib.error.HTTPError as exc:
-        raise LaunchError(f"MCP server HTTP {exc.code}: {exc.reason}") from exc
+        raise LaunchError(f"Zing server HTTP {exc.code}: {exc.reason}") from exc
     except (urllib.error.URLError, ConnectionRefusedError, OSError) as exc:
         raise LaunchError(
-            f"Could not connect to Zing MCP server at {server_url}. Is 'zing-ai mcp' running?"
+            f"Could not connect to Zing server at {server_url}. Is 'zing-ai mcp' running?"
         ) from exc
-    except json.JSONDecodeError as exc:
-        raise LaunchError(f"MCP server returned non-JSON response: {exc}") from exc
-
-
-def create_mcp_session(
-    server_url: str,
-    session_id: str,
-    title: str,
-    ticket_id: str,
-    worktree_path: str | None,
-    skill: str | None,
-) -> None:
-    """Create a ``ClaudeCodeSession`` on the MCP server.
-
-    Args:
-        server_url: MCP server URL.
-        session_id: Unique session identifier.
-        title: Human-readable session title.
-        ticket_id: Linear ticket ID associated with this session.
-        worktree_path: Absolute path of the worktree, or ``None``.
-        skill: Skill/command name, or ``None``.
-
-    Raises:
-        LaunchError: If the MCP call fails.
-    """
-    arguments: dict = {
-        "session_id": session_id,
-        "title": title,
-        "ticket_id": ticket_id,
-        "type": "ClaudeCodeSession",
-    }
-    if worktree_path is not None:
-        arguments["worktree_path"] = worktree_path
-    if skill is not None:
-        arguments["skill"] = skill
-
-    _call_mcp_http(server_url, "session_create", arguments)
 
 
 def detect_action(
@@ -590,35 +566,36 @@ def detect_action(
 ) -> tuple[Literal["resume", "new"], str | None]:
     """Check whether an existing Claude Code session exists for *ticket_id*.
 
-    Calls the MCP server to list sessions and finds any ``ClaudeCodeSession``
-    with a matching ``ticket_id``.
+    Calls ``GET /api/sessions?ticket_id=<id>`` and finds any session with
+    ``session_type == "claude_code"``.
 
     Args:
         ticket_id: Linear ticket ID to look for.
-        server_url: MCP server URL.
+        server_url: Base URL of the Zing server.
 
     Returns:
         ``("resume", session_id)`` if a matching session is found, otherwise
         ``("new", None)``.
 
     Raises:
-        LaunchError: If the MCP call fails.
+        LaunchError: If the HTTP call fails.
     """
-    resp = _call_mcp_http(server_url, "session_list", {})
-    # Response may be a JSON-RPC result wrapping the list, or the list directly.
-    sessions: list[dict] = []
-    if isinstance(resp, list):
-        sessions = resp
-    elif isinstance(resp, dict):
-        # JSON-RPC 2.0 envelope
-        result = resp.get("result", resp)
-        if isinstance(result, list):
-            sessions = result
-        elif isinstance(result, dict):
-            sessions = result.get("sessions", [])
+    url = f"{server_url.rstrip('/')}/api/sessions?ticket_id={ticket_id}"
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            sessions: list[dict] = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        raise LaunchError(f"Zing server HTTP {exc.code}: {exc.reason}") from exc
+    except (urllib.error.URLError, ConnectionRefusedError, OSError) as exc:
+        raise LaunchError(
+            f"Could not connect to Zing server at {server_url}. Is 'zing-ai mcp' running?"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise LaunchError(f"Zing server returned non-JSON response: {exc}") from exc
 
     for session in sessions:
-        if session.get("type") == "ClaudeCodeSession" and session.get("ticket_id") == ticket_id:
+        if session.get("session_type") == "claude_code":
             return ("resume", session["session_id"])
 
     return ("new", None)

--- a/src/zing_ai/launch.py
+++ b/src/zing_ai/launch.py
@@ -14,6 +14,7 @@ Workflow mode notes
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
@@ -274,6 +275,19 @@ def checkout_pr_branch(
     relative = worktree_root_template.format(repo=repo_name, branch=branch_name)
     worktree_path = (repo_root / relative).resolve()
 
+    # Best-effort fetch so the branch exists locally for worktree add
+    with contextlib.suppress(subprocess.CalledProcessError):
+        subprocess.run(
+            ["git", "fetch", "origin", branch_name],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+
+    # Reuse existing worktree if it already exists at the expected path
+    if worktree_path.is_dir():
+        return worktree_path
+
     try:
         subprocess.run(
             ["git", "worktree", "add", str(worktree_path), branch_name],
@@ -321,10 +335,10 @@ def run_init_script(
     worktree_path: Path,
     branch: str,
 ) -> None:
-    """Run the repository's init script inside the worktree directory, if present.
+    """Run the repository's init script from the repo root, if present.
 
     Looks for ``<repo_root>/<script_name>``.  If the file exists, runs it as a
-    subprocess from *worktree_path* with the following environment variables:
+    subprocess from *repo_root* with the following environment variables:
 
     - ``ZING_BRANCH`` — *branch*
     - ``ZING_WORKTREE_PATH`` — absolute string of *worktree_path*
@@ -356,7 +370,7 @@ def run_init_script(
             check=True,
             capture_output=True,
             text=True,
-            cwd=worktree_path,
+            cwd=repo_root,
             env=env,
         )
     except subprocess.CalledProcessError as exc:
@@ -518,6 +532,8 @@ def create_session_on_server(
     ticket_id: str | None,
     worktree_path: str | None,
     skill: str | None,
+    pr_number: int | None = None,
+    pr_repo: str | None = None,
 ) -> None:
     """Create a ``ClaudeCodeSession`` on the Zing server via REST.
 
@@ -531,6 +547,8 @@ def create_session_on_server(
         ticket_id: Linear ticket ID, or ``None``.
         worktree_path: Absolute worktree path, or ``None``.
         skill: Skill/command name, or ``None``.
+        pr_number: GitHub PR number, or ``None``.
+        pr_repo: GitHub repo as ``"owner/repo"``, or ``None``.
 
     Raises:
         LaunchError: If the HTTP call fails.
@@ -541,6 +559,8 @@ def create_session_on_server(
         "ticket_id": ticket_id,
         "worktree_path": worktree_path,
         "skill": skill,
+        "pr_number": pr_number,
+        "pr_repo": pr_repo,
     }
     body = json.dumps(payload).encode()
     req = urllib.request.Request(
@@ -608,26 +628,25 @@ def detect_action(
 
 def build_claude_args(
     skill: str,
-    ticket_id: str | None,
     session_id: str,
     name: str,
+    target: str | None = None,
 ) -> list[str]:
     """Build the argv list to pass to ``os.execvp("claude", ...)`` .
 
-    Three modes are supported:
+    Modes:
 
     - ``skill == "resume"``: ``["claude", "--resume", session_id]``
-    - ``skill == "pr-audit"``: ``["claude", "/zing:pr-audit", "--session-id", session_id,
-      "--name", name]``
-    - anything else (e.g. ``"new"``): ``["claude", "/zing:new <ticket_id>", "--session-id",
+    - anything else: ``["claude", "/zing:<skill> <target>", "--session-id",
       session_id, "--name", name]``
 
     Args:
-        skill: One of ``"resume"``, ``"pr-audit"``, or a new-session skill (e.g. ``"new"``).
-        ticket_id: Linear ticket ID, used in the new-session slash command.  May be ``None``
-            for resume/pr-audit flows.
+        skill: Skill name (e.g. ``"resume"``, ``"new"``, ``"pr-audit"``,
+            ``"pr-audit-visual"``).
         session_id: Claude session identifier.
         name: Session display name.
+        target: Argument passed to the slash command (ticket ID for new-ticket
+            flows, PR URL for PR flows).  Omitted from the command when ``None``.
 
     Returns:
         List of strings suitable for ``os.execvp``.
@@ -635,9 +654,5 @@ def build_claude_args(
     if skill == "resume":
         return ["claude", "--resume", session_id]
 
-    if skill == "pr-audit":
-        return ["claude", "/zing:pr-audit", "--session-id", session_id, "--name", name]
-
-    # Default: new ticket session
-    slash_cmd = f"/zing:new {ticket_id}" if ticket_id else "/zing:new"
+    slash_cmd = f"/zing:{skill} {target}" if target else f"/zing:{skill}"
     return ["claude", slash_cmd, "--session-id", session_id, "--name", name]

--- a/src/zing_ai/launch.py
+++ b/src/zing_ai/launch.py
@@ -32,10 +32,12 @@ class LaunchError(Exception):
 
 
 # ---------------------------------------------------------------------------
-# Ticket ID regex (same pattern as command_center.py)
+# Ticket ID pattern — canonical source. Other modules import this.
 # ---------------------------------------------------------------------------
 
-_TICKET_RE = re.compile(r"\b[A-Z]{2,}-\d+\b")
+TICKET_ID_PATTERN = r"[A-Z]{2,}-\d+"
+
+_TICKET_RE = re.compile(rf"\b{TICKET_ID_PATTERN}\b")
 
 # ---------------------------------------------------------------------------
 # PR URL helpers
@@ -284,9 +286,19 @@ def checkout_pr_branch(
             cwd=repo_root,
         )
 
-    # Reuse existing worktree if it already exists at the expected path
+    # Reuse existing worktree if it already exists and is a valid git checkout
     if worktree_path.is_dir():
-        return worktree_path
+        try:
+            subprocess.run(
+                ["git", "rev-parse", "--is-inside-work-tree"],
+                check=True,
+                capture_output=True,
+                text=True,
+                cwd=worktree_path,
+            )
+            return worktree_path
+        except subprocess.CalledProcessError:
+            pass  # directory exists but isn't a valid worktree — fall through to create
 
     try:
         subprocess.run(

--- a/src/zing_ai/server/command_center.py
+++ b/src/zing_ai/server/command_center.py
@@ -232,6 +232,32 @@ def _classify_card(
     return "todo"
 
 
+def _user_involved_in_done_card(card: KanbanCard, current_username: str) -> bool:
+    """Return True if the user authored or reviewed any PR on this card.
+
+    For ticket-only cards (no PRs), always include them (they're the user's
+    assigned tickets).
+    """
+    if not card.prs:
+        return True  # ticket-only card, no PR filter needed
+    return any(
+        pr.author == current_username or current_username in pr.requested_reviewers
+        for pr in card.prs
+    )
+
+
+def _assign_done_group(card: KanbanCard) -> str:
+    """Return the done sub-group for a done card.
+
+    - ``ready_to_merge``: has an open PR that is approved but not yet merged
+    - ``completed``: merged PRs or completed tickets
+    """
+    for pr in card.prs:
+        if pr.state == "open" and pr.review_decision == "APPROVED":
+            return "ready_to_merge"
+    return "completed"
+
+
 def _todo_sort_key(card: KanbanCard) -> tuple:
     """Sort key for todo column.
 
@@ -381,7 +407,8 @@ def aggregate(
         elif column == "needs_review":
             view.needs_review.append(card)
         elif column == "done":
-            view.done.append(card)
+            if _user_involved_in_done_card(card, _username):
+                view.done.append(card)
         else:
             view.todo.append(card)
 
@@ -404,5 +431,14 @@ def aggregate(
     # Sort needs_review by group order: mine_passing, mine_failing, others
     _GROUP_ORDER = {"mine_passing": 0, "mine_failing": 1, "others": 2}
     view.needs_review.sort(key=lambda c: _GROUP_ORDER.get(c.review_group or "", 3))
+
+    # -----------------------------------------------------------------------
+    # 10. Assign done groups and sort: ready_to_merge first, then completed
+    # -----------------------------------------------------------------------
+    for card in view.done:
+        card.done_group = _assign_done_group(card)
+
+    _DONE_GROUP_ORDER = {"ready_to_merge": 0, "completed": 1}
+    view.done.sort(key=lambda c: _DONE_GROUP_ORDER.get(c.done_group or "", 2))
 
     return view

--- a/src/zing_ai/server/command_center.py
+++ b/src/zing_ai/server/command_center.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime, timedelta
 
-from zing_ai.server.models import Session, SessionState, WorkflowStep
+from zing_ai.server.models import Session, SessionState, WorkflowStep, ZingSession
 from zing_ai.server.models_external import (
     GitHubPR,
     KanbanCard,
@@ -81,8 +81,9 @@ def _card_most_recent_activity(card: KanbanCard) -> datetime:
         if pr.merged_at is not None:
             candidates.append(pr.merged_at)
     for session in card.sessions:
-        for step in session.steps:
-            candidates.append(step.created_at)
+        if isinstance(session, ZingSession):
+            for step in session.steps:
+                candidates.append(step.created_at)
     if not candidates:
         return datetime.min.replace(tzinfo=UTC)
     return max(_ensure_utc(dt) for dt in candidates)
@@ -94,7 +95,10 @@ def _card_most_recent_activity(card: KanbanCard) -> datetime:
 def _has_active_session(card: KanbanCard) -> bool:
     """Any session has a step in STARTED state."""
     return any(
-        step.state == SessionState.STARTED for session in card.sessions for step in session.steps
+        step.state == SessionState.STARTED
+        for session in card.sessions
+        if isinstance(session, ZingSession)
+        for step in session.steps
     )
 
 
@@ -329,10 +333,11 @@ def aggregate(
             continue  # exclude standalone sessions
         if session.ticket_id in cards:
             cards[session.ticket_id].sessions.append(session)
-            # Surface audit steps
-            for step in session.steps:
-                if step.step_name in AUDIT_STEP_NAMES:
-                    cards[session.ticket_id].audit_steps.append(step)
+            # Surface audit steps (ZingSession only — ClaudeCodeSession has no steps)
+            if isinstance(session, ZingSession):
+                for step in session.steps:
+                    if step.step_name in AUDIT_STEP_NAMES:
+                        cards[session.ticket_id].audit_steps.append(step)
 
     # -----------------------------------------------------------------------
     # 5. Orphan PR cards (no matching ticket)

--- a/src/zing_ai/server/command_center.py
+++ b/src/zing_ai/server/command_center.py
@@ -236,12 +236,16 @@ def _user_involved_in_done_card(card: KanbanCard, current_username: str) -> bool
     """Return True if the user authored or reviewed any PR on this card.
 
     For ticket-only cards (no PRs), always include them (they're the user's
-    assigned tickets).
+    assigned tickets).  Checks both ``requested_reviewers`` (pending reviews)
+    and ``reviewers`` (submitted reviews) to cover approved PRs where the
+    reviewer is no longer in ``requested_reviewers``.
     """
     if not card.prs:
         return True  # ticket-only card, no PR filter needed
     return any(
-        pr.author == current_username or current_username in pr.requested_reviewers
+        pr.author == current_username
+        or current_username in pr.requested_reviewers
+        or current_username in pr.reviewers
         for pr in card.prs
     )
 

--- a/src/zing_ai/server/command_center.py
+++ b/src/zing_ai/server/command_center.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime, timedelta
 
+from zing_ai.launch import TICKET_ID_PATTERN
 from zing_ai.server.models import (
     ClaudeCodeSession,
     Session,
@@ -46,10 +47,10 @@ def _actionable_findings(step: WorkflowStep) -> list:
     return [f for f in step.findings if getattr(f, "type", None) != "evaluation"]
 
 
-# Ticket ids look like ``BAK-1179`` / ``FRO-42``. Require two+ letter prefixes
-# and word boundaries so noisy tokens like ``UTF-8``/``SHA-256``/``PR-1`` don't
-# masquerade as tickets. Length-1 team keys aren't used by Linear in practice.
-_TICKET_RE = re.compile(r"\b[A-Z]{2,}-\d+\b", re.IGNORECASE)
+# Ticket ids look like ``BAK-1179`` / ``FRO-42``. Uses the shared pattern from
+# launch.py with word boundaries and case-insensitive matching so noisy tokens
+# like ``UTF-8``/``SHA-256``/``PR-1`` don't masquerade as tickets.
+_TICKET_RE = re.compile(rf"\b{TICKET_ID_PATTERN}\b", re.IGNORECASE)
 _PR_NUMBER_RE = re.compile(r"#(\d+)\b")
 
 
@@ -114,6 +115,7 @@ def _card_most_recent_activity(card: KanbanCard) -> datetime:
         if pr.merged_at is not None:
             candidates.append(pr.merged_at)
     for session in card.sessions:
+        candidates.append(session.created_at)
         if isinstance(session, ZingSession):
             for step in session.steps:
                 candidates.append(step.created_at)
@@ -126,15 +128,18 @@ def _card_most_recent_activity(card: KanbanCard) -> datetime:
 
 
 def _has_active_session(card: KanbanCard) -> bool:
-    """Any session is active (ClaudeCodeSession or ZingSession with a STARTED step)."""
-    for session in card.sessions:
-        if isinstance(session, ClaudeCodeSession):
-            return True
-        if isinstance(session, ZingSession) and any(
-            step.state == SessionState.STARTED for step in session.steps
-        ):
-            return True
-    return False
+    """Any ZingSession has a step in STARTED state.
+
+    ClaudeCodeSession is intentionally excluded — it has no lifecycle
+    states, so treating it as always-active would permanently pin cards
+    to In Progress.  It still renders as a session indicator on the card.
+    """
+    return any(
+        step.state == SessionState.STARTED
+        for session in card.sessions
+        if isinstance(session, ZingSession)
+        for step in session.steps
+    )
 
 
 def _has_open_pr_in_progress(card: KanbanCard, current_username: str) -> bool:
@@ -419,23 +424,32 @@ def aggregate(
     # -----------------------------------------------------------------------
     orphan_cards: dict[str, KanbanCard] = {}
     for pr in orphan_prs:
-        key = f"pr-{pr.number}"
+        key = f"pr-{pr.repo}-{pr.number}" if pr.repo else f"pr-{pr.number}"
         orphan_cards[key] = KanbanCard(
             key=key,
             ticket=None,
             prs=[pr],
         )
 
-    # Attach sessions that matched by PR number (from step 4)
+    # Attach sessions that matched by PR number (from step 4).
+    # ClaudeCodeSession has pr_repo for exact matching; ZingSession falls back
+    # to matching by PR number suffix across all orphan card keys.
     for session in pr_sessions:
         pr_num = _session_pr_number(session)
-        key = f"pr-{pr_num}"
-        if key in orphan_cards:
-            orphan_cards[key].sessions.append(session)
+        pr_repo = getattr(session, "pr_repo", None) or ""
+        key = f"pr-{pr_repo}-{pr_num}" if pr_repo else None
+        if key and key in orphan_cards:
+            target_card = orphan_cards[key]
+        else:
+            # Fallback: match by PR number suffix (for ZingSessions without repo info)
+            suffix = f"-{pr_num}"
+            target_card = next((c for k, c in orphan_cards.items() if k.endswith(suffix)), None)
+        if target_card is not None:
+            target_card.sessions.append(session)
             if isinstance(session, ZingSession):
                 for step in session.steps:
                     if step.step_name in AUDIT_STEP_NAMES:
-                        orphan_cards[key].audit_steps.append(step)
+                        target_card.audit_steps.append(step)
 
     # -----------------------------------------------------------------------
     # 6. Collect all cards and filter empties

--- a/src/zing_ai/server/command_center.py
+++ b/src/zing_ai/server/command_center.py
@@ -11,7 +11,13 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime, timedelta
 
-from zing_ai.server.models import Session, SessionState, WorkflowStep, ZingSession
+from zing_ai.server.models import (
+    ClaudeCodeSession,
+    Session,
+    SessionState,
+    WorkflowStep,
+    ZingSession,
+)
 from zing_ai.server.models_external import (
     GitHubPR,
     KanbanCard,
@@ -44,6 +50,33 @@ def _actionable_findings(step: WorkflowStep) -> list:
 # and word boundaries so noisy tokens like ``UTF-8``/``SHA-256``/``PR-1`` don't
 # masquerade as tickets. Length-1 team keys aren't used by Linear in practice.
 _TICKET_RE = re.compile(r"\b[A-Z]{2,}-\d+\b", re.IGNORECASE)
+_PR_NUMBER_RE = re.compile(r"#(\d+)\b")
+
+
+def _session_pr_number(session: Session) -> int | None:
+    """Extract a PR number from a session, if available.
+
+    For ``ClaudeCodeSession``, uses the explicit ``pr_number`` field only.
+    For ``ZingSession``, parses ``#<number>`` from the title (e.g.
+    ``"PR Review — #1858 feat: ..."``) or session_id (e.g.
+    ``"pr-review-1858-..."``)
+
+    Title/ID parsing is intentionally skipped for ``ClaudeCodeSession``
+    because those sessions may carry a ``ticket_id`` that failed to match
+    a card — falling back to title parsing would incorrectly attach them
+    to an orphan PR card.
+    """
+    if isinstance(session, ClaudeCodeSession):
+        return session.pr_number  # explicit field only, may be None
+    # ZingSession: try title first: "PR Review — #1858 ..."
+    match = _PR_NUMBER_RE.search(session.title)
+    if match:
+        return int(match.group(1))
+    # Try session_id: "pr-review-1858-..."
+    id_match = re.match(r"pr-review-(\d+)-", session.session_id)
+    if id_match:
+        return int(id_match.group(1))
+    return None
 
 
 def _parse_ticket_id(pr: GitHubPR) -> str | None:
@@ -93,13 +126,15 @@ def _card_most_recent_activity(card: KanbanCard) -> datetime:
 
 
 def _has_active_session(card: KanbanCard) -> bool:
-    """Any session has a step in STARTED state."""
-    return any(
-        step.state == SessionState.STARTED
-        for session in card.sessions
-        if isinstance(session, ZingSession)
-        for step in session.steps
-    )
+    """Any session is active (ClaudeCodeSession or ZingSession with a STARTED step)."""
+    for session in card.sessions:
+        if isinstance(session, ClaudeCodeSession):
+            return True
+        if isinstance(session, ZingSession) and any(
+            step.state == SessionState.STARTED for step in session.steps
+        ):
+            return True
+    return False
 
 
 def _has_open_pr_in_progress(card: KanbanCard, current_username: str) -> bool:
@@ -129,8 +164,8 @@ def _has_pr_needing_review(card: KanbanCard, current_username: str) -> bool:
     return False
 
 
-def _is_recently_done(card: KanbanCard, cutoff: datetime) -> bool:
-    """Ticket completed or PR merged/approved within the cutoff window."""
+def _is_recently_done(card: KanbanCard, cutoff: datetime, current_username: str = "") -> bool:
+    """Ticket completed, PR merged/approved, or user submitted a review within the cutoff."""
     if (
         card.ticket is not None
         and card.ticket.state_type == "completed"
@@ -147,6 +182,15 @@ def _is_recently_done(card: KanbanCard, cutoff: datetime) -> bool:
             return True
         if pr.review_decision == "APPROVED" and _ensure_utc(pr.updated_at) >= cutoff:
             return True
+        # User submitted a review — their review work is done
+        if (
+            pr.state == "open"
+            and current_username
+            and current_username in pr.reviewers
+            and current_username not in pr.requested_reviewers
+            and _ensure_utc(pr.updated_at) >= cutoff
+        ):
+            return True
 
     return False
 
@@ -156,13 +200,15 @@ def _is_recently_done(card: KanbanCard, cutoff: datetime) -> bool:
 
 def _should_include_card(card: KanbanCard, current_username: str, cutoff: datetime) -> bool:
     """Return False when the card should be excluded from the board entirely."""
-    # Orphan-PR cards where the user is neither author nor reviewer.
+    # Orphan-PR cards where the user is neither author nor reviewer and has no session.
     if card.ticket is None and card.prs:
         user_involved = any(
-            pr.author == current_username or current_username in pr.requested_reviewers
+            pr.author == current_username
+            or current_username in pr.requested_reviewers
+            or current_username in pr.reviewers
             for pr in card.prs
         )
-        if not user_involved:
+        if not user_involved and not card.sessions:
             return False
 
     # Stale approved PRs: all PRs approved, none updated within the done window,
@@ -222,7 +268,7 @@ def _classify_card(
     if _has_pr_needing_review(card, current_username):
         return "needs_review"
 
-    if _is_recently_done(card, cutoff):
+    if _is_recently_done(card, cutoff, current_username):
         return "done"
 
     # Ticket is actively being worked on but no PR signal drove it elsewhere.
@@ -352,37 +398,50 @@ def aggregate(
                 orphan_prs.append(pr)
 
     # -----------------------------------------------------------------------
-    # 4. Attach sessions; skip standalone sessions (no ticket_id)
+    # 4. Attach sessions; skip standalone sessions (no ticket_id and no pr_number)
     # -----------------------------------------------------------------------
+    # Sessions that have a pr_number but no ticket_id will be attached to
+    # orphan PR cards (keyed as "pr-{number}") in step 5 below.
+    pr_sessions: list[Session] = []
     for session in _sessions:
-        if not session.ticket_id:
-            continue  # exclude standalone sessions
-        if session.ticket_id in cards:
+        if session.ticket_id and session.ticket_id in cards:
             cards[session.ticket_id].sessions.append(session)
             # Surface audit steps (ZingSession only — ClaudeCodeSession has no steps)
             if isinstance(session, ZingSession):
                 for step in session.steps:
                     if step.step_name in AUDIT_STEP_NAMES:
                         cards[session.ticket_id].audit_steps.append(step)
+        elif _session_pr_number(session) is not None:
+            pr_sessions.append(session)
 
     # -----------------------------------------------------------------------
     # 5. Orphan PR cards (no matching ticket)
     # -----------------------------------------------------------------------
-    orphan_cards: list[KanbanCard] = []
+    orphan_cards: dict[str, KanbanCard] = {}
     for pr in orphan_prs:
-        orphan_cards.append(
-            KanbanCard(
-                key=f"pr-{pr.number}",
-                ticket=None,
-                prs=[pr],
-            )
+        key = f"pr-{pr.number}"
+        orphan_cards[key] = KanbanCard(
+            key=key,
+            ticket=None,
+            prs=[pr],
         )
+
+    # Attach sessions that matched by PR number (from step 4)
+    for session in pr_sessions:
+        pr_num = _session_pr_number(session)
+        key = f"pr-{pr_num}"
+        if key in orphan_cards:
+            orphan_cards[key].sessions.append(session)
+            if isinstance(session, ZingSession):
+                for step in session.steps:
+                    if step.step_name in AUDIT_STEP_NAMES:
+                        orphan_cards[key].audit_steps.append(step)
 
     # -----------------------------------------------------------------------
     # 6. Collect all cards and filter empties
     # -----------------------------------------------------------------------
     all_cards: list[KanbanCard] = [c for c in cards.values() if c.ticket is not None or c.prs] + [
-        c for c in orphan_cards if c.prs
+        c for c in orphan_cards.values() if c.prs
     ]
 
     # -----------------------------------------------------------------------

--- a/src/zing_ai/server/command_center.py
+++ b/src/zing_ai/server/command_center.py
@@ -233,21 +233,17 @@ def _classify_card(
 
 
 def _user_involved_in_done_card(card: KanbanCard, current_username: str) -> bool:
-    """Return True if the user authored or reviewed any PR on this card.
+    """Return True if the user authored or actually reviewed any PR on this card.
 
     For ticket-only cards (no PRs), always include them (they're the user's
-    assigned tickets).  Checks both ``requested_reviewers`` (pending reviews)
-    and ``reviewers`` (submitted reviews) to cover approved PRs where the
-    reviewer is no longer in ``requested_reviewers``.
+    assigned tickets).  Only checks ``author`` and ``reviewers`` (submitted
+    reviews) — being in ``requested_reviewers`` alone is not enough, since the
+    user may have been requested but never reviewed (e.g. PR was approved by
+    someone else).
     """
     if not card.prs:
         return True  # ticket-only card, no PR filter needed
-    return any(
-        pr.author == current_username
-        or current_username in pr.requested_reviewers
-        or current_username in pr.reviewers
-        for pr in card.prs
-    )
+    return any(pr.author == current_username or current_username in pr.reviewers for pr in card.prs)
 
 
 def _assign_done_group(card: KanbanCard) -> str:

--- a/src/zing_ai/server/github_client.py
+++ b/src/zing_ai/server/github_client.py
@@ -62,6 +62,17 @@ def _map_pr(pr: dict, *, repo: str = "") -> GitHubPR:
         if node.get("requestedReviewer") and "login" in node["requestedReviewer"]
     ]
 
+    # latestReviews nodes contain author objects; surface user logins only.
+    latest_reviews = pr.get("latestReviews") or {}
+    review_nodes = latest_reviews.get("nodes") or []
+    reviewers = list(
+        {
+            node["author"]["login"]
+            for node in review_nodes
+            if node.get("author") and "login" in node["author"]
+        }
+    )
+
     # CI status lives at commits -> last commit -> statusCheckRollup
     commits = pr.get("commits") or {}
     commit_nodes = commits.get("nodes") or []
@@ -119,6 +130,7 @@ def _map_pr(pr: dict, *, repo: str = "") -> GitHubPR:
         author=author,
         repo=repo,
         requested_reviewers=requested_reviewers,
+        reviewers=reviewers,
         review_decision=pr.get("reviewDecision"),
         mergeable_state=mergeable_state,
         ci_status=ci_status,
@@ -241,6 +253,11 @@ class GitHubClient:
                     requestedReviewer {
                       ... on User { login }
                     }
+                  }
+                }
+                latestReviews(first: 10) {
+                  nodes {
+                    author { login }
                   }
                 }
                 commits(last: 1) {

--- a/src/zing_ai/server/linear_client.py
+++ b/src/zing_ai/server/linear_client.py
@@ -51,7 +51,9 @@ query MyOpenIssues($viewerId: ID!, $first: Int!, $after: String) {
 """
 
 _COMPLETED_ISSUES_QUERY = """
-query MyCompletedIssues($viewerId: ID!, $first: Int!, $after: String, $since: DateTimeComparators) {
+query MyCompletedIssues(
+  $viewerId: ID!, $first: Int!, $after: String, $since: NullableDateComparator
+) {
   issues(
     first: $first,
     after: $after,

--- a/src/zing_ai/server/models.py
+++ b/src/zing_ai/server/models.py
@@ -354,6 +354,8 @@ class ClaudeCodeSession(SessionBase):
     session_type: Literal["claude_code"] = "claude_code"
     worktree_path: str | None = None
     skill: str | None = None
+    pr_number: int | None = None
+    pr_repo: str | None = None
 
     @property
     def state(self) -> SessionState:

--- a/src/zing_ai/server/models.py
+++ b/src/zing_ai/server/models.py
@@ -8,7 +8,7 @@ from enum import StrEnum
 from typing import Annotated, Any, Literal
 from uuid import uuid4
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, model_validator
 
 
 class Location(BaseModel):
@@ -280,18 +280,24 @@ class WorkflowStep(BaseModel):
         return data
 
 
-class Session(BaseModel):
-    """A review session containing workflow steps with findings and responses."""
+class SessionBase(BaseModel):
+    """Shared base for all session types."""
 
     model_config = ConfigDict(extra="ignore")
 
     session_id: str
     title: str
-    zing_file: str | None = None
     ticket_id: str | None = None
+    created_at: datetime = Field(default_factory=datetime.now)
+
+
+class ZingSession(SessionBase):
+    """A review session containing workflow steps with findings and responses."""
+
+    session_type: Literal["zing"] = "zing"
+    zing_file: str | None = None
     steps: list[WorkflowStep] = Field(default_factory=list)
     notifications: list[Notification] = Field(default_factory=list)
-    created_at: datetime = Field(default_factory=datetime.now)
 
     @model_validator(mode="before")
     @classmethod
@@ -340,6 +346,34 @@ class Session(BaseModel):
     def total_findings(self) -> int:
         """Return the total number of findings across all steps."""
         return sum(len(step.findings) for step in self.steps)
+
+
+class ClaudeCodeSession(SessionBase):
+    """An interactive Claude Code session launched from the Command Center."""
+
+    session_type: Literal["claude_code"] = "claude_code"
+    worktree_path: str | None = None
+    skill: str | None = None
+
+    @property
+    def state(self) -> SessionState:
+        """Return the session state. ClaudeCodeSessions are always STARTED."""
+        return SessionState.STARTED
+
+
+def _session_discriminator(data: Any) -> str:
+    """Return session_type, defaulting to 'zing' for old JSON files that lack it."""
+    if isinstance(data, dict):
+        return data.get("session_type", "zing")
+    if hasattr(data, "session_type"):
+        return data.session_type
+    return "zing"
+
+
+Session = Annotated[
+    Annotated[ZingSession, Tag("zing")] | Annotated[ClaudeCodeSession, Tag("claude_code")],
+    Discriminator(_session_discriminator),
+]
 
 
 class ReviewItem(BaseModel):

--- a/src/zing_ai/server/models_external.py
+++ b/src/zing_ai/server/models_external.py
@@ -47,6 +47,7 @@ class GitHubPR(BaseModel):
     author: str = ""
     repo: str = ""
     requested_reviewers: list[str]
+    reviewers: list[str] = Field(default_factory=list)  # users who submitted reviews
     review_decision: Literal["APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED"] | None
     mergeable_state: str
     ci_status: str | None

--- a/src/zing_ai/server/models_external.py
+++ b/src/zing_ai/server/models_external.py
@@ -72,6 +72,7 @@ class KanbanCard(BaseModel):
     sessions: list[Session] = Field(default_factory=list)
     audit_steps: list[WorkflowStep] = Field(default_factory=list)
     review_group: str | None = None  # mine_passing, mine_failing, others (needs_review only)
+    done_group: str | None = None  # ready_to_merge, completed (done only)
 
 
 class KanbanView(BaseModel):

--- a/src/zing_ai/server/routes.py
+++ b/src/zing_ai/server/routes.py
@@ -16,6 +16,7 @@ from datastar_py.consts import ElementPatchMode
 from datastar_py.fastapi import datastar_response
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
+from pydantic import BaseModel
 
 from zing_ai.server.html_fragments import (
     build_notification_script as _build_notification_script,
@@ -707,6 +708,73 @@ async def post_cleanup(
     manager.cleanup_session(session_id)
     logger.info("Session %s cleaned up via dashboard", session_id)
     return SSE.redirect("/dashboard")
+
+
+# ---------------------------------------------------------------------------
+# REST API endpoints for external callers (e.g. zing-ai launch)
+# ---------------------------------------------------------------------------
+
+
+class _CreateClaudeCodeSessionBody(BaseModel):  # type: ignore[misc]
+    """Request body for POST /api/sessions/claude-code."""
+
+    session_id: str
+    title: str
+    ticket_id: str | None = None
+    worktree_path: str | None = None
+    skill: str | None = None
+
+
+@router.post("/api/sessions/claude-code")
+async def post_create_claude_code_session(
+    body: _CreateClaudeCodeSessionBody,
+    request: Request,
+) -> JSONResponse:
+    """Create a ClaudeCodeSession and persist it via SessionManager.
+
+    Args:
+        body: Session creation parameters.
+        request: The incoming request.
+
+    Returns:
+        JSON with ``status`` and ``session_id``.
+    """
+    manager = request.app.state.session_manager
+    try:
+        session = manager.create_claude_code_session(
+            session_id=body.session_id,
+            title=body.title,
+            ticket_id=body.ticket_id,
+            worktree_path=body.worktree_path,
+            skill=body.skill,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return JSONResponse({"status": "created", "session_id": session.session_id})
+
+
+@router.get("/api/sessions")
+async def get_sessions(
+    request: Request,
+    ticket_id: str | None = None,
+) -> JSONResponse:
+    """Return a list of sessions, optionally filtered by ticket_id.
+
+    Args:
+        request: The incoming request.
+        ticket_id: Optional filter — only return sessions with this ticket_id.
+
+    Returns:
+        JSON list of session dicts.
+    """
+    manager = request.app.state.session_manager
+    sessions = manager.list_sessions()
+    result = []
+    for session in sessions:
+        d = session.model_dump(mode="json")
+        if ticket_id is None or session.ticket_id == ticket_id:
+            result.append(d)
+    return JSONResponse(result)
 
 
 @router.get("/{session_id}", response_model=None)

--- a/src/zing_ai/server/routes.py
+++ b/src/zing_ai/server/routes.py
@@ -723,6 +723,8 @@ class _CreateClaudeCodeSessionBody(BaseModel):  # type: ignore[misc]
     ticket_id: str | None = None
     worktree_path: str | None = None
     skill: str | None = None
+    pr_number: int | None = None
+    pr_repo: str | None = None
 
 
 @router.post("/api/sessions/claude-code")
@@ -747,6 +749,8 @@ async def post_create_claude_code_session(
             ticket_id=body.ticket_id,
             worktree_path=body.worktree_path,
             skill=body.skill,
+            pr_number=body.pr_number,
+            pr_repo=body.pr_repo,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/src/zing_ai/server/routes.py
+++ b/src/zing_ai/server/routes.py
@@ -773,11 +773,11 @@ async def get_sessions(
     """
     manager = request.app.state.session_manager
     sessions = manager.list_sessions()
-    result = []
-    for session in sessions:
-        d = session.model_dump(mode="json")
-        if ticket_id is None or session.ticket_id == ticket_id:
-            result.append(d)
+    result = [
+        session.model_dump(mode="json")
+        for session in sessions
+        if ticket_id is None or session.ticket_id == ticket_id
+    ]
     return JSONResponse(result)
 
 

--- a/src/zing_ai/server/routes_command_center.py
+++ b/src/zing_ai/server/routes_command_center.py
@@ -61,8 +61,8 @@ def _view_fingerprint(cache, sessions: list) -> tuple:  # noqa: ANN001
         (
             s.session_id,
             s.ticket_id,
-            len(s.steps),
-            s.steps[-1].state.value if s.steps else "",
+            len(steps) if (steps := getattr(s, "steps", None)) else 0,
+            steps[-1].state.value if steps else "",
         )
         for s in sessions
     )

--- a/src/zing_ai/server/routes_command_center.py
+++ b/src/zing_ai/server/routes_command_center.py
@@ -98,7 +98,12 @@ def _build_view(app: FastAPI) -> KanbanView:
 def render_board_fragment(app: FastAPI) -> str:
     """Render the full kanban board. Used by SSE board_changed events."""
     view = _build_view(app)
-    return render("fragments/kanban_board.html", view=view)  # hub disappeared between events
+    cache = app.state.external_cache
+    return render(
+        "fragments/kanban_board.html",
+        view=view,
+        current_username=cache.github_username or "",
+    )  # hub disappeared between events
 
 
 @router.get("/command-center", response_class=HTMLResponse)
@@ -115,6 +120,7 @@ async def get_command_center(request: Request) -> HTMLResponse:
             last_polled_label=_format_last_polled(cache.last_polled_at),
             last_error=cache.last_error,
             body_class="command-center",
+            current_username=cache.github_username or "",
         )
     )
 

--- a/src/zing_ai/server/sessions.py
+++ b/src/zing_ai/server/sessions.py
@@ -20,6 +20,7 @@ from pydantic import TypeAdapter
 from zing_ai.server.models import (
     Agent,
     AgentState,
+    ClaudeCodeSession,
     Finding,
     LogEntry,
     Notification,
@@ -183,6 +184,46 @@ class SessionManager:
         self._notify("session_created", session_id)
         self._notify(f"notification_added:{notif.id}", session_id)
         logger.info("Created session %s: %s", session_id, title)
+        return session
+
+    def create_claude_code_session(
+        self,
+        session_id: str,
+        title: str,
+        ticket_id: str | None = None,
+        worktree_path: str | None = None,
+        skill: str | None = None,
+    ) -> ClaudeCodeSession:
+        """Create a new ClaudeCodeSession and persist it.
+
+        Args:
+            session_id: Caller-provided unique session identifier.
+            title: Human-readable session title.
+            ticket_id: Linear ticket ID, or None.
+            worktree_path: Absolute worktree path, or None.
+            skill: Skill/command name, or None.
+
+        Returns:
+            The newly created ClaudeCodeSession.
+
+        Raises:
+            ValueError: If session_id is invalid or already exists.
+        """
+        self._validate_session_id(session_id)
+        if session_id in self._sessions:
+            msg = f"Session already exists: {session_id}"
+            raise ValueError(msg)
+        session = ClaudeCodeSession(
+            session_id=session_id,
+            title=title,
+            ticket_id=ticket_id,
+            worktree_path=worktree_path,
+            skill=skill,
+        )
+        self._sessions[session_id] = session
+        self._persist(session)
+        self._notify("session_created", session_id)
+        logger.info("Created ClaudeCodeSession %s: %s", session_id, title)
         return session
 
     def update_session(

--- a/src/zing_ai/server/sessions.py
+++ b/src/zing_ai/server/sessions.py
@@ -29,6 +29,7 @@ from zing_ai.server.models import (
     SessionState,
     UserResponse,
     WorkflowStep,
+    ZingSession,
 )
 
 _LOG_LEVEL = os.environ.get("ZING_LOG_LEVEL", "INFO").upper()
@@ -43,6 +44,7 @@ if not logger.handlers:
 _DEFAULT_DATA_DIR = Path.home() / ".local" / "share" / "zing-ai" / "sessions"
 _SAFE_SESSION_ID = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
 _FINDING_ADAPTER = TypeAdapter(Finding)
+_SESSION_ADAPTER = TypeAdapter(Session)
 
 
 class SessionManager:
@@ -105,22 +107,29 @@ class SessionManager:
         for path in self._data_dir.glob("*.json"):
             try:
                 data = json.loads(path.read_text(encoding="utf-8"))
-                session = Session.model_validate(data)
+                session = _SESSION_ADAPTER.validate_python(data)
                 self._sessions[session.session_id] = session
-                # Index steps by step_id and create events
-                for i, step in enumerate(session.steps):
-                    self._steps_by_id[step.step_id] = (session.session_id, i)
-                for step in session.steps:
-                    key = self._event_key(session.session_id, step.step_id)
-                    self._events[key] = asyncio.Event()
-                    if step.state == SessionState.COMPLETED:
-                        self._events[key].set()
-                logger.info(
-                    "Loaded session %s from disk (state=%s, steps=%d)",
-                    session.session_id,
-                    session.state.value,
-                    len(session.steps),
-                )
+                # Index steps by step_id and create events (ZingSession only)
+                if isinstance(session, ZingSession):
+                    for i, step in enumerate(session.steps):
+                        self._steps_by_id[step.step_id] = (session.session_id, i)
+                    for step in session.steps:
+                        key = self._event_key(session.session_id, step.step_id)
+                        self._events[key] = asyncio.Event()
+                        if step.state == SessionState.COMPLETED:
+                            self._events[key].set()
+                    logger.info(
+                        "Loaded session %s from disk (state=%s, steps=%d)",
+                        session.session_id,
+                        session.state.value,
+                        len(session.steps),
+                    )
+                else:
+                    logger.info(
+                        "Loaded session %s from disk (type=%s)",
+                        session.session_id,
+                        session.session_type,
+                    )
             except Exception:
                 logger.exception("Failed to load session from %s", path)
 
@@ -130,7 +139,7 @@ class SessionManager:
         title: str,
         zing_file: str | None = None,
         steps: list[str] | None = None,
-    ) -> Session:
+    ) -> ZingSession:
         """Create a new review session.
 
         Args:
@@ -159,7 +168,7 @@ class SessionManager:
                 logger.warning("Rejected zing_file (not markdown): %s", zing_file)
                 msg = f"zing_file must be a markdown file (.md), got: {zing_file}"
                 raise ValueError(msg)
-        session = Session(session_id=session_id, title=title, zing_file=zing_file)
+        session = ZingSession(session_id=session_id, title=title, zing_file=zing_file)
         if steps:
             for i, step_name in enumerate(steps):
                 step = WorkflowStep(step_name=step_name, sequence=i)
@@ -198,6 +207,9 @@ class SessionManager:
         """
         session = self._get_session_or_raise(session_id)
         if zing_file is not None:
+            if not isinstance(session, ZingSession):
+                msg = f"zing_file can only be set on ZingSession, got: {session.session_type}"
+                raise ValueError(msg)
             if not os.path.isabs(zing_file):
                 logger.warning("Rejected zing_file (not absolute): %s", zing_file)
                 msg = f"zing_file must be an absolute path, got: {zing_file}"
@@ -292,27 +304,31 @@ class SessionManager:
             KeyError: If no step with that name exists in the session.
         """
         session = self._get_session_or_raise(session_id)
+        if not isinstance(session, ZingSession):
+            raise KeyError(f"Session {session_id} is not a ZingSession")
         for step in reversed(session.steps):
             if step.step_name == step_name:
                 return step
         raise KeyError(f"No step '{step_name}' found in session '{session_id}'")
 
-    def get_step_by_id(self, step_id: str) -> tuple[Session, WorkflowStep]:
+    def get_step_by_id(self, step_id: str) -> tuple[ZingSession, WorkflowStep]:
         """Return the session and step for a given step_id.
 
         Args:
             step_id: The UUID of the step.
 
         Returns:
-            Tuple of (Session, WorkflowStep).
+            Tuple of (ZingSession, WorkflowStep).
 
         Raises:
-            KeyError: If no step with that ID exists.
+            KeyError: If no step with that ID exists, or the session is not a ZingSession.
         """
         if step_id not in self._steps_by_id:
             raise KeyError(f"No step with id '{step_id}' found")
         session_id, step_index = self._steps_by_id[step_id]
         session = self._get_session_or_raise(session_id)
+        if not isinstance(session, ZingSession):
+            raise KeyError(f"Session {session_id} is not a ZingSession")
         return session, session.steps[step_index]
 
     def add_finding(self, session_id: str, step_id: str, finding_data: dict[str, Any]) -> Finding:
@@ -753,7 +769,7 @@ class SessionManager:
             session_id: The session to remove.
         """
         session = self._sessions.pop(session_id, None)
-        if session:
+        if session and isinstance(session, ZingSession):
             for step in session.steps:
                 self._steps_by_id.pop(step.step_id, None)
                 key = self._event_key(session_id, step.step_id)
@@ -778,6 +794,8 @@ class SessionManager:
     ) -> Notification:
         """Create a notification, append it to the session, persist, and notify."""
         session = self._get_session_or_raise(session_id)
+        if not isinstance(session, ZingSession):
+            raise KeyError(f"Session {session_id} is not a ZingSession")
         notification = Notification(title=title, body=body, url=url)
         session.notifications.append(notification)
         self._persist(session)

--- a/src/zing_ai/server/sessions.py
+++ b/src/zing_ai/server/sessions.py
@@ -193,6 +193,8 @@ class SessionManager:
         ticket_id: str | None = None,
         worktree_path: str | None = None,
         skill: str | None = None,
+        pr_number: int | None = None,
+        pr_repo: str | None = None,
     ) -> ClaudeCodeSession:
         """Create a new ClaudeCodeSession and persist it.
 
@@ -202,6 +204,8 @@ class SessionManager:
             ticket_id: Linear ticket ID, or None.
             worktree_path: Absolute worktree path, or None.
             skill: Skill/command name, or None.
+            pr_number: GitHub PR number, or None.
+            pr_repo: GitHub repo as ``"owner/repo"``, or None.
 
         Returns:
             The newly created ClaudeCodeSession.
@@ -219,6 +223,8 @@ class SessionManager:
             ticket_id=ticket_id,
             worktree_path=worktree_path,
             skill=skill,
+            pr_number=pr_number,
+            pr_repo=pr_repo,
         )
         self._sessions[session_id] = session
         self._persist(session)

--- a/src/zing_ai/server/static/css/command_center.css
+++ b/src/zing_ai/server/static/css/command_center.css
@@ -147,6 +147,10 @@ details.review-group[open] > .review-group-header::before {
     color: var(--gray-400);
 }
 
+.review-group-ready-to-merge .review-group-title {
+    color: #2e7d32;
+}
+
 /* ──────────────────────────────────────────────
    CARDS
 ────────────────────────────────────────────── */

--- a/src/zing_ai/server/static/css/command_center.css
+++ b/src/zing_ai/server/static/css/command_center.css
@@ -416,6 +416,77 @@ a.ci-failing-name:hover {
 }
 
 /* ──────────────────────────────────────────────
+   LAUNCH BUTTONS
+────────────────────────────────────────────── */
+
+.launch-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.2rem 0.55rem;
+    background: var(--gray-50);
+    color: var(--gray-700);
+    border: 1px solid var(--gray-200);
+    border-radius: 6px;
+    font-size: 0.65rem;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    text-decoration: none;
+    white-space: nowrap;
+    min-width: 5.5rem;
+    justify-content: center;
+}
+
+.launch-btn:hover {
+    background: var(--gray-100);
+    border-color: var(--gray-300);
+    color: var(--navy);
+}
+
+.launch-btn:active {
+    background: var(--gray-200);
+    transform: translateY(1px);
+}
+
+/* Muted variant for secondary actions like "Respond to Review" */
+.launch-btn-secondary {
+    background: transparent;
+    color: var(--gray-500);
+    border-color: var(--gray-100);
+}
+
+.launch-btn-secondary:hover {
+    background: var(--gray-50);
+    border-color: var(--gray-200);
+    color: var(--gray-700);
+}
+
+/* Flex row container for multiple launch buttons */
+.launch-btn-group {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-top: 0.4rem;
+}
+
+/* ──────────────────────────────────────────────
+   SESSION INDICATORS (CLAUDE CODE vs ZING)
+────────────────────────────────────────────── */
+
+/* Blue dot for Claude Code sessions */
+.dot-blue { background: #3b82f6; }
+
+/* Claude Code session indicator — blue-tinted to distinguish from Zing (amber) */
+.session-indicator.claude-code {
+    background: #eff6ff;
+    border-color: #bfdbfe;
+    color: #1d4ed8;
+}
+
+/* ──────────────────────────────────────────────
    ANIMATIONS
 ────────────────────────────────────────────── */
 

--- a/src/zing_ai/server/templates/command_center.html
+++ b/src/zing_ai/server/templates/command_center.html
@@ -15,7 +15,20 @@
          data-text="$lastError"
          {% if not last_error %}style="display: none"{% endif %}>{{ last_error or '' }}</div>
 
-    {% include "fragments/kanban_board.html" %}
+{% include "fragments/kanban_board.html" %}
+
+    <script>
+    document.addEventListener('click', function(e) {
+        var btn = e.target.closest('[data-launch-cmd]');
+        if (!btn) return;
+        var cmd = btn.getAttribute('data-launch-cmd');
+        var label = btn.getAttribute('data-launch-label');
+        navigator.clipboard.writeText(cmd).then(function() {
+            btn.textContent = 'Copied!';
+            setTimeout(function() { btn.textContent = label; }, 1500);
+        });
+    });
+    </script>
 
     <footer class="cc-footer">
         <span data-text="$lastPolledLabel ? `Last synced ${$lastPolledLabel}` : 'Waiting for first poll'">{{ "Last synced " + last_polled_label if last_polled_label else "Waiting for first poll" }}</span>

--- a/src/zing_ai/server/templates/fragments/finding.html
+++ b/src/zing_ai/server/templates/fragments/finding.html
@@ -41,7 +41,7 @@
         <div class="triage-options-label">Suggested approaches:</div>
         {% for option in finding.options %}
         <label class="option-card">
-            <input type="radio" name="approach-{{ finding.id }}" data-bind="responses.{{ finding.id }}_approach" value="{{ option.label }}" data-on:change="@post('/{{ session_id }}/save-response', {step_id: $step_id, finding_id: '{{ finding.id }}', selected: $responses['{{ finding.id }}_approach']})">
+            <input type="radio" name="approach-{{ finding.id }}" data-bind="responses.{{ finding.id }}_approach" value="{{ option.label }}" data-on:change="$responses.{{ finding.id }} = 'accept'; @post('/{{ session_id }}/save-response', {step_id: $step_id, finding_id: '{{ finding.id }}', action: 'accept', selected: $responses['{{ finding.id }}_approach']})">
             <div class="option-content">
                 <div class="option-label">{{ option.label }}</div>
                 <div class="option-description">{{ option.description }}</div>
@@ -49,7 +49,7 @@
         </label>
         {% endfor %}
         <label class="option-card">
-            <input type="radio" name="approach-{{ finding.id }}" data-bind="responses.{{ finding.id }}_approach" value="__other__" data-on:change="@post('/{{ session_id }}/save-response', {step_id: $step_id, finding_id: '{{ finding.id }}', selected: $responses['{{ finding.id }}_approach']})">
+            <input type="radio" name="approach-{{ finding.id }}" data-bind="responses.{{ finding.id }}_approach" value="__other__" data-on:change="$responses.{{ finding.id }} = 'accept'; @post('/{{ session_id }}/save-response', {step_id: $step_id, finding_id: '{{ finding.id }}', action: 'accept', selected: $responses['{{ finding.id }}_approach']})">
             <div class="option-content">
                 <div class="option-label">Other</div>
                 <div class="option-description">Describe a different approach</div>

--- a/src/zing_ai/server/templates/fragments/kanban_board.html
+++ b/src/zing_ai/server/templates/fragments/kanban_board.html
@@ -9,6 +9,6 @@
     {% include "fragments/kanban_column_review.html" %}
   {% endwith %}
   {% with column_name="Done", column_cls="col-done", column_id="col-done", cards=view.done %}
-    {% include "fragments/kanban_column.html" %}
+    {% include "fragments/kanban_column_done.html" %}
   {% endwith %}
 </div>

--- a/src/zing_ai/server/templates/fragments/kanban_card.html
+++ b/src/zing_ai/server/templates/fragments/kanban_card.html
@@ -72,8 +72,16 @@
     {% endif %}
   {% endfor %}
 
-  {# ── Session indicators ── #}
-  {% for session in card.sessions %}
+  {# ── Claude Code session indicators ── #}
+  {% for session in card.sessions if session.session_type == 'claude_code' %}
+    <div class="session-indicator claude-code">
+      <span class="status-dot dot-blue"></span>
+      <span>Claude Code: {{ session.title }}</span>
+    </div>
+  {% endfor %}
+
+  {# ── Zing session indicators (existing rendering) ── #}
+  {% for session in card.sessions if session.session_type == 'zing' %}
     {% set state_val = session.state.value %}
     <div class="session-indicator{% if state_val == 'started' %} active{% elif state_val == 'pending' %} waiting{% elif state_val == 'completed' %} done{% endif %}">
       {% if state_val == 'started' %}
@@ -100,6 +108,30 @@
   {% if card.sessions %}
     <div class="tags">
       <span class="tag tag-session">Claude</span>
+    </div>
+  {% endif %}
+
+  {# ── Launch button ── #}
+  {% if card.ticket %}
+    {% set launch_cmd = "zing-ai launch " + card.key %}
+    {% set launch_label = "Resume Session" if card.sessions | selectattr("session_type", "equalto", "claude_code") | list else "Plan Ticket" %}
+    <button class="launch-btn"
+            data-on-click="navigator.clipboard.writeText({{ launch_cmd | tojson }}); $el.textContent='Copied!'; setTimeout(() => $el.textContent={{ launch_label | tojson }}, 1500)">
+      {{ launch_label }}
+    </button>
+  {% elif card.prs %}
+    {% set is_author = card.prs[0].author == current_username %}
+    <div class="launch-btn-group">
+      <button class="launch-btn"
+              data-on-click="navigator.clipboard.writeText({{ ('zing-ai launch ' + card.prs[0].url) | tojson }}); $el.textContent='Copied!'; setTimeout(() => $el.textContent='Start Review', 1500)">
+        Start Review
+      </button>
+      {% if is_author %}
+        <button class="launch-btn launch-btn-secondary"
+                data-on-click="navigator.clipboard.writeText({{ ('zing-ai launch --skill pr-respond ' + card.prs[0].url) | tojson }}); $el.textContent='Copied!'; setTimeout(() => $el.textContent='Respond to Review', 1500)">
+          Respond to Review
+        </button>
+      {% endif %}
     </div>
   {% endif %}
 

--- a/src/zing_ai/server/templates/fragments/kanban_card.html
+++ b/src/zing_ai/server/templates/fragments/kanban_card.html
@@ -115,20 +115,17 @@
   {% if card.ticket %}
     {% set launch_cmd = "zing-ai launch " + card.key %}
     {% set launch_label = "Resume Session" if card.sessions | selectattr("session_type", "equalto", "claude_code") | list else "Plan Ticket" %}
-    <button class="launch-btn"
-            data-on:click="navigator.clipboard.writeText({{ launch_cmd | tojson }}); $el.textContent='Copied!'; setTimeout(() => $el.textContent={{ launch_label | tojson }}, 1500)">
+    <button class="launch-btn" data-launch-cmd="{{ launch_cmd | e }}" data-launch-label="{{ launch_label | e }}">
       {{ launch_label }}
     </button>
   {% elif card.prs %}
     {% set is_author = card.prs[0].author == current_username %}
     <div class="launch-btn-group">
-      <button class="launch-btn"
-              data-on:click="navigator.clipboard.writeText({{ ('zing-ai launch ' + card.prs[0].url) | tojson }}); $el.textContent='Copied!'; setTimeout(() => $el.textContent='Start Review', 1500)">
+      <button class="launch-btn" data-launch-cmd="zing-ai launch {{ card.prs[0].url | e }}" data-launch-label="Start Review">
         Start Review
       </button>
       {% if is_author %}
-        <button class="launch-btn launch-btn-secondary"
-                data-on:click="navigator.clipboard.writeText({{ ('zing-ai launch --skill pr-respond ' + card.prs[0].url) | tojson }}); $el.textContent='Copied!'; setTimeout(() => $el.textContent='Respond to Review', 1500)">
+        <button class="launch-btn launch-btn-secondary" data-launch-cmd="zing-ai launch --skill pr-respond {{ card.prs[0].url | e }}" data-launch-label="Respond to Review">
           Respond to Review
         </button>
       {% endif %}

--- a/src/zing_ai/server/templates/fragments/kanban_card.html
+++ b/src/zing_ai/server/templates/fragments/kanban_card.html
@@ -116,19 +116,19 @@
     {% set launch_cmd = "zing-ai launch " + card.key %}
     {% set launch_label = "Resume Session" if card.sessions | selectattr("session_type", "equalto", "claude_code") | list else "Plan Ticket" %}
     <button class="launch-btn"
-            data-on-click="navigator.clipboard.writeText({{ launch_cmd | tojson }}); $el.textContent='Copied!'; setTimeout(() => $el.textContent={{ launch_label | tojson }}, 1500)">
+            data-on:click="navigator.clipboard.writeText({{ launch_cmd | tojson }}); $el.textContent='Copied!'; setTimeout(() => $el.textContent={{ launch_label | tojson }}, 1500)">
       {{ launch_label }}
     </button>
   {% elif card.prs %}
     {% set is_author = card.prs[0].author == current_username %}
     <div class="launch-btn-group">
       <button class="launch-btn"
-              data-on-click="navigator.clipboard.writeText({{ ('zing-ai launch ' + card.prs[0].url) | tojson }}); $el.textContent='Copied!'; setTimeout(() => $el.textContent='Start Review', 1500)">
+              data-on:click="navigator.clipboard.writeText({{ ('zing-ai launch ' + card.prs[0].url) | tojson }}); $el.textContent='Copied!'; setTimeout(() => $el.textContent='Start Review', 1500)">
         Start Review
       </button>
       {% if is_author %}
         <button class="launch-btn launch-btn-secondary"
-                data-on-click="navigator.clipboard.writeText({{ ('zing-ai launch --skill pr-respond ' + card.prs[0].url) | tojson }}); $el.textContent='Copied!'; setTimeout(() => $el.textContent='Respond to Review', 1500)">
+                data-on:click="navigator.clipboard.writeText({{ ('zing-ai launch --skill pr-respond ' + card.prs[0].url) | tojson }}); $el.textContent='Copied!'; setTimeout(() => $el.textContent='Respond to Review', 1500)">
           Respond to Review
         </button>
       {% endif %}

--- a/src/zing_ai/server/templates/fragments/kanban_card.html
+++ b/src/zing_ai/server/templates/fragments/kanban_card.html
@@ -83,7 +83,7 @@
   {# ── Zing session indicators (existing rendering) ── #}
   {% for session in card.sessions if session.session_type == 'zing' %}
     {% set state_val = session.state.value %}
-    <div class="session-indicator{% if state_val == 'started' %} active{% elif state_val == 'pending' %} waiting{% elif state_val == 'completed' %} done{% endif %}">
+    <a href="/{{ session.session_id }}" class="session-indicator{% if state_val == 'started' %} active{% elif state_val == 'pending' %} waiting{% elif state_val == 'completed' %} done{% endif %}">
       {% if state_val == 'started' %}
         <span class="status-dot dot-amber"></span>
       {% elif state_val == 'pending' %}
@@ -101,7 +101,7 @@
         {% else %}{{ state_val }}
         {% endif %}
       </span>
-    </div>
+    </a>
   {% endfor %}
 
   {# ── Tags row ── #}

--- a/src/zing_ai/server/templates/fragments/kanban_column_done.html
+++ b/src/zing_ai/server/templates/fragments/kanban_column_done.html
@@ -1,0 +1,46 @@
+{#
+  kanban_column_done.html — renders the "Done" column with
+  optional "Ready to Merge" section at the top.
+
+  Expected context variables:
+    column_name  — display name, e.g. "Done"
+    column_cls   — CSS class, e.g. "col-done"
+    column_id    — element id, e.g. "col-done"
+    cards        — list[KanbanCard] (pre-sorted by done_group)
+#}
+{% set ready_to_merge = cards | selectattr("done_group", "equalto", "ready_to_merge") | list %}
+{% set completed = cards | selectattr("done_group", "equalto", "completed") | list %}
+
+<div class="column {{ column_cls }}" id="{{ column_id }}">
+  <div class="column-header">
+    {{ column_name }}
+    <span class="count">{{ cards | length }}</span>
+  </div>
+  <div class="card-list">
+    {% if not cards %}
+      <div class="column-empty">Nothing here</div>
+    {% endif %}
+
+    {% if ready_to_merge %}
+      <details class="review-group" open>
+        <summary class="review-group-header review-group-ready-to-merge">
+          <span class="review-group-title">Ready to merge</span>
+          <span class="review-group-count">{{ ready_to_merge | length }}</span>
+        </summary>
+        {% for card in ready_to_merge %}
+          {% with column_cls=column_cls %}
+            {% include "fragments/kanban_card.html" %}
+          {% endwith %}
+        {% endfor %}
+      </details>
+    {% endif %}
+
+    {% if completed %}
+      {% for card in completed %}
+        {% with column_cls=column_cls %}
+          {% include "fragments/kanban_card.html" %}
+        {% endwith %}
+      {% endfor %}
+    {% endif %}
+  </div>
+</div>

--- a/tests/test_command_center/conftest.py
+++ b/tests/test_command_center/conftest.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
-from zing_ai.server.models import Session, SessionState, WorkflowStep
+from zing_ai.server.models import Session, SessionState, WorkflowStep, ZingSession
 from zing_ai.server.models_external import GitHubPR, LinearIssue
 
 
@@ -90,7 +90,7 @@ def make_session(
     steps: list[WorkflowStep] | None = None,
 ) -> Session:
     """Build a :class:`Session` with sensible defaults for tests."""
-    return Session(
+    return ZingSession(
         session_id=session_id,
         title=title,
         ticket_id=ticket_id,

--- a/tests/test_command_center/conftest.py
+++ b/tests/test_command_center/conftest.py
@@ -13,7 +13,13 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
-from zing_ai.server.models import Session, SessionState, WorkflowStep, ZingSession
+from zing_ai.server.models import (
+    ClaudeCodeSession,
+    Session,
+    SessionState,
+    WorkflowStep,
+    ZingSession,
+)
 from zing_ai.server.models_external import GitHubPR, LinearIssue
 
 
@@ -55,12 +61,15 @@ def make_pr(
     base_ref: str = "main",
     author: str = "octocat",
     requested_reviewers: list[str] | None = None,
+    reviewers: list[str] | None = None,
     review_decision: str | None = None,
+    repo: str = "org/repo",
     mergeable_state: str = "clean",
     ci_status: str | None = None,
     ci_checks: list[Any] | None = None,
     url: str | None = None,
     updated_at: datetime | None = None,
+    merged_at: datetime | None = None,
 ) -> GitHubPR:
     """Build a :class:`GitHubPR` with sensible defaults for tests."""
     return GitHubPR(
@@ -72,13 +81,16 @@ def make_pr(
         base_ref=base_ref,
         body=body,
         author=author,
+        repo=repo,
         requested_reviewers=requested_reviewers or [],
+        reviewers=reviewers or [],
         review_decision=review_decision,  # type: ignore[arg-type]
         mergeable_state=mergeable_state,
         ci_status=ci_status,
         ci_checks=ci_checks or [],
         url=url or f"https://github.com/o/r/pull/{number}",
         updated_at=updated_at or datetime(2026, 4, 16, 0, 0, 0, tzinfo=UTC),
+        merged_at=merged_at,
     )
 
 
@@ -95,6 +107,24 @@ def make_session(
         title=title,
         ticket_id=ticket_id,
         steps=steps or [],
+    )
+
+
+def make_claude_code_session(
+    *,
+    session_id: str = "cc-1",
+    title: str = "Claude Code Session",
+    ticket_id: str | None = None,
+    pr_number: int | None = None,
+    pr_repo: str | None = None,
+) -> ClaudeCodeSession:
+    """Build a :class:`ClaudeCodeSession` with sensible defaults for tests."""
+    return ClaudeCodeSession(
+        session_id=session_id,
+        title=title,
+        ticket_id=ticket_id,
+        pr_number=pr_number,
+        pr_repo=pr_repo,
     )
 
 

--- a/tests/test_command_center/test_kanban_aggregate.py
+++ b/tests/test_command_center/test_kanban_aggregate.py
@@ -6,6 +6,9 @@ import unittest
 from datetime import UTC, datetime, timedelta
 
 from tests.test_command_center.conftest import (
+    make_claude_code_session as _make_cc_session,
+)
+from tests.test_command_center.conftest import (
     make_issue as _make_issue,
 )
 from tests.test_command_center.conftest import (
@@ -99,7 +102,7 @@ class TestAggregateGrouping(unittest.TestCase):
         view = _agg(prs=[pr])
         cards = _all_cards(view)
         self.assertEqual(len(cards), 1)
-        self.assertEqual(cards[0].key, "pr-99")
+        self.assertEqual(cards[0].key, "pr-org/repo-99")
         self.assertIsNone(cards[0].ticket)
 
     def test_session_with_ticket_id_joins_card(self) -> None:
@@ -468,6 +471,167 @@ class TestFiltering(unittest.TestCase):
         pr = _make_pr(number=7, head_ref="feature/misc", state="open")
         view = _agg(prs=[pr])
         self.assertEqual(len(_all_cards(view)), 1)
+
+
+class TestClaudeCodeSessionClassification(unittest.TestCase):
+    """ClaudeCodeSession should NOT affect column classification."""
+
+    def test_claude_code_session_does_not_pin_to_in_progress(self) -> None:
+        """A card with a ClaudeCodeSession should NOT be pinned to in_progress."""
+        issue = _make_issue(identifier="BAK-10", state_type="unstarted")
+        session = _make_cc_session(ticket_id="BAK-10")
+        view = _agg(issues=[issue], sessions=[session])
+        # Card should be in todo, not in_progress
+        todo_keys = [c.key for c in view.todo]
+        ip_keys = [c.key for c in view.in_progress]
+        self.assertIn("BAK-10", todo_keys)
+        self.assertNotIn("BAK-10", ip_keys)
+
+    def test_completed_ticket_with_claude_session_goes_to_done(self) -> None:
+        """Completed ticket with stale ClaudeCodeSession should be in done, not in_progress."""
+        issue = _make_issue(
+            identifier="BAK-11",
+            state_type="completed",
+            updated_at=RECENT,
+        )
+        session = _make_cc_session(ticket_id="BAK-11")
+        view = _agg(issues=[], completed_issues=[issue], sessions=[session])
+        done_keys = [c.key for c in view.done]
+        ip_keys = [c.key for c in view.in_progress]
+        self.assertIn("BAK-11", done_keys)
+        self.assertNotIn("BAK-11", ip_keys)
+
+
+class TestReviewerDoneClassification(unittest.TestCase):
+    """PRs where the user submitted a review should be classified as done."""
+
+    def test_user_reviewed_pr_is_done(self) -> None:
+        """Open PR where user submitted review and is not re-requested goes to done."""
+        pr = _make_pr(
+            number=42,
+            head_ref="feat/thing",
+            state="open",
+            author="other-dev",
+            reviewers=["octocat"],
+            requested_reviewers=["someone-else"],
+            review_decision="CHANGES_REQUESTED",
+            updated_at=RECENT,
+        )
+        view = _agg(prs=[pr], current_username="octocat")
+        done_keys = [c.key for c in view.done]
+        self.assertTrue(any("42" in k for k in done_keys))
+
+    def test_user_in_requested_reviewers_not_done(self) -> None:
+        """User still in requested_reviewers should NOT be in done via reviewer path."""
+        pr = _make_pr(
+            number=43,
+            head_ref="feat/other",
+            state="open",
+            author="other-dev",
+            reviewers=[],
+            requested_reviewers=["octocat"],
+            review_decision="REVIEW_REQUIRED",
+            updated_at=RECENT,
+        )
+        view = _agg(prs=[pr], current_username="octocat")
+        done_keys = [c.key for c in view.done]
+        self.assertFalse(any("43" in k for k in done_keys))
+
+
+class TestShouldIncludeCardReviewers(unittest.TestCase):
+    """_should_include_card should include orphan PRs where user submitted a review."""
+
+    def test_orphan_pr_included_when_user_is_reviewer(self) -> None:
+        """Orphan PR where user is in reviewers (submitted review) is included."""
+        pr = _make_pr(
+            number=50,
+            head_ref="feat/x",
+            state="open",
+            author="other-dev",
+            reviewers=["octocat"],
+            updated_at=RECENT,
+        )
+        view = _agg(prs=[pr], current_username="octocat")
+        all_keys = [c.key for c in _all_cards(view)]
+        self.assertTrue(any("50" in k for k in all_keys))
+
+    def test_orphan_pr_excluded_when_user_not_involved(self) -> None:
+        """Orphan PR where user is not author, reviewer, or requested is excluded."""
+        pr = _make_pr(
+            number=51,
+            head_ref="feat/y",
+            state="open",
+            author="other-dev",
+            reviewers=["someone-else"],
+            updated_at=RECENT,
+        )
+        view = _agg(prs=[pr], current_username="octocat")
+        all_keys = [c.key for c in _all_cards(view)]
+        self.assertFalse(any("51" in k for k in all_keys))
+
+
+class TestSessionPrNumberLinking(unittest.TestCase):
+    """Sessions should link to orphan PR cards by PR number."""
+
+    def test_zing_session_linked_by_title(self) -> None:
+        """ZingSession with '#42' in title attaches to orphan PR card."""
+        pr = _make_pr(number=42, head_ref="feat/thing", author="octocat")
+        session = _make_session(
+            session_id="pr-review-42-feat-thing-abc123",
+            title="PR Review \u2014 #42 feat: thing",
+        )
+        view = _agg(prs=[pr], sessions=[session], current_username="octocat")
+        cards_with_sessions = [c for c in _all_cards(view) if c.sessions]
+        self.assertEqual(len(cards_with_sessions), 1)
+        self.assertEqual(len(cards_with_sessions[0].sessions), 1)
+
+    def test_claude_code_session_linked_by_pr_number(self) -> None:
+        """ClaudeCodeSession with explicit pr_number attaches to orphan PR card."""
+        pr = _make_pr(number=99, head_ref="fix/bug", author="octocat")
+        session = _make_cc_session(
+            session_id="cc-99",
+            title="PR #99 Review",
+            pr_number=99,
+            pr_repo="org/repo",
+        )
+        view = _agg(prs=[pr], sessions=[session], current_username="octocat")
+        cards_with_sessions = [c for c in _all_cards(view) if c.sessions]
+        self.assertEqual(len(cards_with_sessions), 1)
+
+
+class TestDoneGrouping(unittest.TestCase):
+    """Done column should group cards into ready_to_merge and completed."""
+
+    def test_approved_open_pr_is_ready_to_merge(self) -> None:
+        """Open PR approved by user gets ready_to_merge group in Done."""
+        pr = _make_pr(
+            number=60,
+            head_ref="feat/approved",
+            state="open",
+            author="other-dev",
+            reviewers=["octocat"],
+            review_decision="APPROVED",
+            updated_at=RECENT,
+        )
+        view = _agg(prs=[pr], current_username="octocat")
+        done_cards = view.done
+        ready = [c for c in done_cards if c.done_group == "ready_to_merge"]
+        self.assertEqual(len(ready), 1)
+
+    def test_merged_pr_is_completed(self) -> None:
+        """Merged PR gets completed group."""
+        pr = _make_pr(
+            number=61,
+            head_ref="feat/merged",
+            state="merged",
+            author="octocat",
+            merged_at=RECENT,
+            updated_at=RECENT,
+        )
+        view = _agg(recent_prs=[pr], current_username="octocat")
+        done_cards = view.done
+        completed = [c for c in done_cards if c.done_group == "completed"]
+        self.assertEqual(len(completed), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -13,7 +13,7 @@ from zing_ai.launch import (
     LaunchError,
     build_claude_args,
     checkout_pr_branch,
-    create_mcp_session,
+    create_session_on_server,
     create_worktree,
     derive_branch_name,
     detect_action,
@@ -384,22 +384,24 @@ class TestMoveTicketInProgress(TestCase):
 
 
 # ---------------------------------------------------------------------------
-# create_mcp_session
+# create_session_on_server
 # ---------------------------------------------------------------------------
 
 
-class TestCreateMcpSession(TestCase):
-    """Tests for create_mcp_session."""
+class TestCreateSessionOnServer(TestCase):
+    """Tests for create_session_on_server."""
 
     def test_posts_correct_payload(self) -> None:
         resp_mock = MagicMock()
-        resp_mock.read.return_value = json.dumps({"result": "ok"}).encode()
+        resp_mock.read.return_value = json.dumps(
+            {"status": "created", "session_id": "sess-abc"}
+        ).encode()
         resp_mock.__enter__ = lambda s: s
         resp_mock.__exit__ = MagicMock(return_value=False)
 
         with patch("zing_ai.launch.urllib.request.urlopen", return_value=resp_mock) as mock_open:
-            create_mcp_session(
-                server_url="http://localhost:9876/mcp",
+            create_session_on_server(
+                server_url="http://localhost:9876",
                 session_id="sess-abc",
                 title="My session",
                 ticket_id="BAK-42",
@@ -409,37 +411,35 @@ class TestCreateMcpSession(TestCase):
 
         # Inspect the Request object passed to urlopen
         req = mock_open.call_args[0][0]
+        self.assertIn("/api/sessions/claude-code", req.full_url)
         body = json.loads(req.data.decode())
-        self.assertEqual(body["method"], "tools/call")
-        params = body["params"]
-        self.assertEqual(params["name"], "session_create")
-        args = params["arguments"]
-        self.assertEqual(args["session_id"], "sess-abc")
-        self.assertEqual(args["ticket_id"], "BAK-42")
-        self.assertEqual(args["type"], "ClaudeCodeSession")
-        self.assertEqual(args["worktree_path"], "/tmp/wt")
+        self.assertEqual(body["session_id"], "sess-abc")
+        self.assertEqual(body["ticket_id"], "BAK-42")
+        self.assertEqual(body["worktree_path"], "/tmp/wt")
+        self.assertEqual(body["skill"], "new")
 
-    def test_omits_optional_fields_when_none(self) -> None:
+    def test_includes_none_fields_in_payload(self) -> None:
         resp_mock = MagicMock()
-        resp_mock.read.return_value = json.dumps({}).encode()
+        resp_mock.read.return_value = json.dumps(
+            {"status": "created", "session_id": "sess-xyz"}
+        ).encode()
         resp_mock.__enter__ = lambda s: s
         resp_mock.__exit__ = MagicMock(return_value=False)
 
         with patch("zing_ai.launch.urllib.request.urlopen", return_value=resp_mock) as mock_open:
-            create_mcp_session(
-                server_url="http://localhost:9876/mcp",
+            create_session_on_server(
+                server_url="http://localhost:9876",
                 session_id="sess-xyz",
                 title="Minimal",
-                ticket_id="BAK-1",
+                ticket_id=None,
                 worktree_path=None,
                 skill=None,
             )
 
         req = mock_open.call_args[0][0]
         body = json.loads(req.data.decode())
-        args = body["params"]["arguments"]
-        self.assertNotIn("worktree_path", args)
-        self.assertNotIn("skill", args)
+        self.assertIsNone(body["worktree_path"])
+        self.assertIsNone(body["skill"])
 
 
 # ---------------------------------------------------------------------------
@@ -458,38 +458,37 @@ class TestDetectAction(TestCase):
         return patch("zing_ai.launch.urllib.request.urlopen", return_value=resp_mock)
 
     def test_returns_resume_when_session_found(self) -> None:
+        # GET /api/sessions?ticket_id=BAK-123 returns a plain list
         sessions = [
-            {"type": "ClaudeCodeSession", "ticket_id": "BAK-123", "session_id": "sess-abc"},
-            {"type": "ReviewSession", "ticket_id": "BAK-123", "session_id": "sess-xyz"},
+            {"session_type": "claude_code", "ticket_id": "BAK-123", "session_id": "sess-abc"},
+            {"session_type": "zing", "ticket_id": "BAK-123", "session_id": "sess-xyz"},
         ]
-        with self._mock_urlopen({"result": sessions}):
-            action, sid = detect_action("BAK-123", "http://localhost:9876/mcp")
+        with self._mock_urlopen(sessions):
+            action, sid = detect_action("BAK-123", "http://localhost:9876")
         self.assertEqual(action, "resume")
         self.assertEqual(sid, "sess-abc")
 
     def test_returns_new_when_no_matching_session(self) -> None:
-        sessions = [
-            {"type": "ClaudeCodeSession", "ticket_id": "BAK-999", "session_id": "sess-other"},
-        ]
-        with self._mock_urlopen({"result": sessions}):
-            action, sid = detect_action("BAK-123", "http://localhost:9876/mcp")
+        sessions: list = []
+        with self._mock_urlopen(sessions):
+            action, sid = detect_action("BAK-123", "http://localhost:9876")
         self.assertEqual(action, "new")
         self.assertIsNone(sid)
 
     def test_returns_new_when_session_list_empty(self) -> None:
-        with self._mock_urlopen({"result": []}):
-            action, sid = detect_action("BAK-123", "http://localhost:9876/mcp")
+        with self._mock_urlopen([]):
+            action, sid = detect_action("BAK-123", "http://localhost:9876")
         self.assertEqual(action, "new")
         self.assertIsNone(sid)
 
-    def test_handles_flat_list_response(self) -> None:
+    def test_returns_new_when_only_non_claude_code_sessions(self) -> None:
         sessions = [
-            {"type": "ClaudeCodeSession", "ticket_id": "BAK-5", "session_id": "sess-flat"},
+            {"session_type": "zing", "ticket_id": "BAK-5", "session_id": "sess-zing"},
         ]
         with self._mock_urlopen(sessions):
-            action, sid = detect_action("BAK-5", "http://localhost:9876/mcp")
-        self.assertEqual(action, "resume")
-        self.assertEqual(sid, "sess-flat")
+            action, sid = detect_action("BAK-5", "http://localhost:9876")
+        self.assertEqual(action, "new")
+        self.assertIsNone(sid)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -17,7 +17,10 @@ from zing_ai.launch import (
     create_worktree,
     derive_branch_name,
     detect_action,
+    extract_ticket_id,
+    fetch_pr_data,
     move_ticket_in_progress,
+    parse_pr_url,
     resolve_repo_root,
     rollback_worktree,
     run_init_script,
@@ -537,3 +540,155 @@ class TestBuildClaudeArgs(TestCase):
             args,
             ["claude", "/zing:new BAK-7", "--session-id", "sess-build", "--name", "build session"],
         )
+
+
+# ---------------------------------------------------------------------------
+# parse_pr_url
+# ---------------------------------------------------------------------------
+
+
+class TestParsePrUrl(TestCase):
+    """Tests for parse_pr_url."""
+
+    def test_parses_simple_url(self) -> None:
+        """Standard PR URL returns correct (owner, repo, number)."""
+        owner, repo, number = parse_pr_url("https://github.com/acme/myrepo/pull/42")
+        self.assertEqual(owner, "acme")
+        self.assertEqual(repo, "myrepo")
+        self.assertEqual(number, 42)
+
+    def test_parses_url_with_trailing_path(self) -> None:
+        """PR URL with trailing path segments still extracts core fields."""
+        owner, repo, number = parse_pr_url("https://github.com/acme/myrepo/pull/42/files")
+        self.assertEqual(owner, "acme")
+        self.assertEqual(repo, "myrepo")
+        self.assertEqual(number, 42)
+
+    def test_parses_url_with_multiple_trailing_segments(self) -> None:
+        """PR URL with multiple trailing path segments parses correctly."""
+        owner, repo, number = parse_pr_url("https://github.com/my-org/cool-repo/pull/1234/commits")
+        self.assertEqual(owner, "my-org")
+        self.assertEqual(repo, "cool-repo")
+        self.assertEqual(number, 1234)
+
+    def test_raises_on_non_pr_url(self) -> None:
+        """A GitHub URL that is not a PR URL raises LaunchError."""
+        with self.assertRaises(LaunchError):
+            parse_pr_url("https://github.com/acme/myrepo/issues/42")
+
+    def test_raises_on_invalid_url(self) -> None:
+        """A non-URL string raises LaunchError."""
+        with self.assertRaises(LaunchError):
+            parse_pr_url("not-a-url-at-all")
+
+    def test_raises_on_missing_number(self) -> None:
+        """A PR path without a number raises LaunchError."""
+        with self.assertRaises(LaunchError):
+            parse_pr_url("https://github.com/acme/myrepo/pull/")
+
+
+# ---------------------------------------------------------------------------
+# fetch_pr_data
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPrData(TestCase):
+    """Tests for fetch_pr_data."""
+
+    def test_returns_parsed_json(self) -> None:
+        """When gh succeeds, returns parsed JSON dict."""
+        pr_json = {"headRefName": "bak-123-my-feature", "title": "My PR", "body": "Fixes BAK-123"}
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps(pr_json)
+
+        with (
+            patch("zing_ai.launch.shutil.which", return_value="/usr/bin/gh"),
+            patch("zing_ai.launch.subprocess.run", return_value=mock_result),
+        ):
+            data = fetch_pr_data("acme", "myrepo", 42)
+
+        self.assertEqual(data["headRefName"], "bak-123-my-feature")
+        self.assertEqual(data["title"], "My PR")
+
+    def test_raises_when_gh_not_found(self) -> None:
+        """When gh is not on PATH, raises LaunchError with install URL."""
+        with (
+            patch("zing_ai.launch.shutil.which", return_value=None),
+            self.assertRaises(LaunchError) as ctx,
+        ):
+            fetch_pr_data("acme", "myrepo", 42)
+        self.assertIn("https://cli.github.com/", str(ctx.exception))
+
+    def test_raises_on_gh_command_failure(self) -> None:
+        """CalledProcessError from gh bubbles up as LaunchError."""
+        with (
+            patch("zing_ai.launch.shutil.which", return_value="/usr/bin/gh"),
+            patch(
+                "zing_ai.launch.subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "gh", stderr="not found"),
+            ),
+            self.assertRaises(LaunchError),
+        ):
+            fetch_pr_data("acme", "myrepo", 99)
+
+    def test_calls_gh_with_correct_args(self) -> None:
+        """subprocess.run is called with expected gh arguments."""
+        pr_json = {"headRefName": "main", "title": "T", "body": ""}
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps(pr_json)
+
+        with (
+            patch("zing_ai.launch.shutil.which", return_value="/usr/bin/gh"),
+            patch("zing_ai.launch.subprocess.run", return_value=mock_result) as mock_run,
+        ):
+            fetch_pr_data("org", "repo", 7)
+
+        call_args = mock_run.call_args[0][0]
+        self.assertEqual(call_args[0], "gh")
+        self.assertIn("7", call_args)
+        self.assertIn("org/repo", call_args)
+        self.assertIn("headRefName,title,body", call_args)
+
+
+# ---------------------------------------------------------------------------
+# extract_ticket_id
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTicketId(TestCase):
+    """Tests for extract_ticket_id."""
+
+    def test_extracts_from_branch(self) -> None:
+        """Ticket ID in branch name is returned first."""
+        result = extract_ticket_id("BAK-123-my-feature", "", "")
+        self.assertEqual(result, "BAK-123")
+
+    def test_extracts_from_title(self) -> None:
+        """Ticket ID in title is found when branch has none."""
+        result = extract_ticket_id("feature-branch", "Fix FRO-42 bug", "")
+        self.assertEqual(result, "FRO-42")
+
+    def test_extracts_from_body(self) -> None:
+        """Ticket ID in body is found when branch and title have none."""
+        result = extract_ticket_id("feature-branch", "Some PR", "Closes ENG-99")
+        self.assertEqual(result, "ENG-99")
+
+    def test_branch_takes_priority_over_title(self) -> None:
+        """When both branch and title have tickets, branch wins."""
+        result = extract_ticket_id("BAK-10-thing", "Fixes FRO-20", "")
+        self.assertEqual(result, "BAK-10")
+
+    def test_returns_none_when_no_ticket(self) -> None:
+        """Returns None when no ticket ID pattern is found anywhere."""
+        result = extract_ticket_id("feature-branch", "Some PR title", "No ticket here")
+        self.assertIsNone(result)
+
+    def test_uppercases_result(self) -> None:
+        """Returned ticket ID is always uppercased — input already uppercase."""
+        result = extract_ticket_id("BAK-55-feature", "", "")
+        self.assertEqual(result, "BAK-55")
+
+    def test_ignores_short_prefixes(self) -> None:
+        """Single-letter prefixes like 'A-1' are not matched (need 2+ letter prefix)."""
+        result = extract_ticket_id("A-1", "B-42 fix", "X-99")
+        self.assertIsNone(result)

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -271,7 +271,7 @@ class TestRunInitScript(TestCase):
             mock_run.assert_not_called()
 
     def test_runs_script_with_correct_env_vars(self) -> None:
-        """Script is invoked from worktree dir with the correct env vars."""
+        """Script is invoked from repo root with the correct env vars."""
         import tempfile
 
         with tempfile.TemporaryDirectory() as repo_dir:
@@ -293,7 +293,7 @@ class TestRunInitScript(TestCase):
             self.assertEqual(env["ZING_WORKTREE_PATH"], str(worktree_path))
             self.assertEqual(env["ZING_SPEC_FILE"], "")
             self.assertEqual(env["ZING_SESSION_ID"], "")
-            self.assertEqual(kwargs["cwd"], worktree_path)
+            self.assertEqual(kwargs["cwd"], repo_root)
 
     def test_raises_on_script_failure(self) -> None:
         import tempfile
@@ -500,26 +500,50 @@ class TestBuildClaudeArgs(TestCase):
     """Tests for build_claude_args."""
 
     def test_new_ticket_session(self) -> None:
-        args = build_claude_args("new", "BAK-123", "sess-abc", "my session")
+        args = build_claude_args("new", "sess-abc", "my session", target="BAK-123")
         self.assertEqual(
             args,
             ["claude", "/zing:new BAK-123", "--session-id", "sess-abc", "--name", "my session"],
         )
 
     def test_pr_audit_session(self) -> None:
-        args = build_claude_args("pr-audit", None, "sess-xyz", "pr session")
+        pr_url = "https://github.com/acme/repo/pull/42"
+        args = build_claude_args("pr-audit", "sess-xyz", "pr session", target=pr_url)
         self.assertEqual(
             args,
-            ["claude", "/zing:pr-audit", "--session-id", "sess-xyz", "--name", "pr session"],
+            [
+                "claude",
+                f"/zing:pr-audit {pr_url}",
+                "--session-id",
+                "sess-xyz",
+                "--name",
+                "pr session",
+            ],
+        )
+
+    def test_pr_audit_visual_session(self) -> None:
+        """Any pr-* skill produces /zing:<skill> <target>."""
+        pr_url = "https://github.com/acme/repo/pull/99"
+        args = build_claude_args("pr-audit-visual", "sess-vis", "visual review", target=pr_url)
+        self.assertEqual(
+            args,
+            [
+                "claude",
+                f"/zing:pr-audit-visual {pr_url}",
+                "--session-id",
+                "sess-vis",
+                "--name",
+                "visual review",
+            ],
         )
 
     def test_resume_session(self) -> None:
-        args = build_claude_args("resume", "BAK-123", "sess-old", "old session")
+        args = build_claude_args("resume", "sess-old", "old session")
         self.assertEqual(args, ["claude", "--resume", "sess-old"])
 
-    def test_new_without_ticket_id(self) -> None:
-        """When ticket_id is None for a new session, omit it from the slash command."""
-        args = build_claude_args("new", None, "sess-no-ticket", "unticketed")
+    def test_new_without_target(self) -> None:
+        """When target is None, omit it from the slash command."""
+        args = build_claude_args("new", "sess-no-ticket", "unticketed")
         self.assertEqual(
             args,
             [
@@ -533,11 +557,18 @@ class TestBuildClaudeArgs(TestCase):
         )
 
     def test_custom_skill(self) -> None:
-        """Any skill other than 'resume' or 'pr-audit' produces a new-session argv."""
-        args = build_claude_args("build", "BAK-7", "sess-build", "build session")
+        """Any skill produces /zing:<skill> <target>."""
+        args = build_claude_args("build", "sess-build", "build session", target="BAK-7")
         self.assertEqual(
             args,
-            ["claude", "/zing:new BAK-7", "--session-id", "sess-build", "--name", "build session"],
+            [
+                "claude",
+                "/zing:build BAK-7",
+                "--session-id",
+                "sess-build",
+                "--name",
+                "build session",
+            ],
         )
 
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,0 +1,539 @@
+"""Tests for zing_ai.launch — core launch logic."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from zing_ai.launch import (
+    LaunchError,
+    build_claude_args,
+    checkout_pr_branch,
+    create_mcp_session,
+    create_worktree,
+    derive_branch_name,
+    detect_action,
+    move_ticket_in_progress,
+    resolve_repo_root,
+    rollback_worktree,
+    run_init_script,
+)
+
+# ---------------------------------------------------------------------------
+# resolve_repo_root
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRepoRoot(TestCase):
+    """Tests for resolve_repo_root."""
+
+    def _make_run(self, toplevel: str, worktree_list: str) -> Callable[..., MagicMock]:
+        """Return a mock for subprocess.run that yields the given outputs."""
+
+        def fake_run(cmd, **kwargs):
+            result = MagicMock()
+            if "rev-parse" in cmd:
+                result.stdout = toplevel + "\n"
+            elif "worktree" in cmd and "list" in cmd:
+                result.stdout = worktree_list
+            return result
+
+        return fake_run
+
+    def test_returns_main_root_when_not_in_worktree(self, tmp_path: Path | None = None) -> None:
+        """When the current root IS the main worktree, return it unchanged."""
+        current = "/repo/main"
+        wt_list = f"worktree {current}\nHEAD abc123\nbranch refs/heads/main\n\n"
+        fake_run = self._make_run(current, wt_list)
+
+        with patch("zing_ai.launch.subprocess.run", side_effect=fake_run):
+            result = resolve_repo_root(Path("/repo/main"))
+
+        self.assertEqual(result, Path(current))
+
+    def test_returns_main_root_when_in_worktree(self) -> None:
+        """When in a linked worktree, return the main worktree root."""
+        main = "/repo/main"
+        linked = "/repo/worktrees/feature"
+        wt_list = (
+            f"worktree {main}\nHEAD abc\nbranch refs/heads/main\n\n"
+            f"worktree {linked}\nHEAD def\nbranch refs/heads/feature\n\n"
+        )
+        fake_run = self._make_run(linked, wt_list)
+
+        with patch("zing_ai.launch.subprocess.run", side_effect=fake_run):
+            result = resolve_repo_root(Path(linked))
+
+        self.assertEqual(result, Path(main))
+
+    def test_raises_launch_error_on_rev_parse_failure(self) -> None:
+        """CalledProcessError from git rev-parse bubbles up as LaunchError."""
+        with (
+            patch(
+                "zing_ai.launch.subprocess.run",
+                side_effect=subprocess.CalledProcessError(128, "git", stderr="not a git repo"),
+            ),
+            self.assertRaises(LaunchError),
+        ):
+            resolve_repo_root(Path("/not/a/repo"))
+
+    def test_raises_launch_error_on_worktree_list_failure(self) -> None:
+        """CalledProcessError from git worktree list bubbles up as LaunchError."""
+        call_count = 0
+
+        def fake_run(cmd, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                result = MagicMock()
+                result.stdout = "/repo/main\n"
+                return result
+            raise subprocess.CalledProcessError(128, "git", stderr="oops")
+
+        with (
+            patch("zing_ai.launch.subprocess.run", side_effect=fake_run),
+            self.assertRaises(LaunchError),
+        ):
+            resolve_repo_root(Path("/repo/main"))
+
+
+# ---------------------------------------------------------------------------
+# derive_branch_name
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveBranchName(TestCase):
+    """Tests for derive_branch_name."""
+
+    def _mock_urlopen(self, response_data: dict):
+        """Context manager mock for urllib.request.urlopen."""
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = json.dumps(response_data).encode()
+        resp_mock.__enter__ = lambda s: s
+        resp_mock.__exit__ = MagicMock(return_value=False)
+        return patch("zing_ai.launch.urllib.request.urlopen", return_value=resp_mock)
+
+    def test_returns_branch_name(self) -> None:
+        data = {"data": {"issue": {"branchName": "zing/bak-123-do-the-thing"}}}
+        with self._mock_urlopen(data):
+            result = derive_branch_name("BAK-123", "api-key")
+        self.assertEqual(result, "zing/bak-123-do-the-thing")
+
+    def test_raises_on_missing_data(self) -> None:
+        data = {"data": {"issue": None}}
+        with self._mock_urlopen(data), self.assertRaises(LaunchError):
+            derive_branch_name("BAK-999", "api-key")
+
+    def test_raises_on_empty_branch_name(self) -> None:
+        data = {"data": {"issue": {"branchName": ""}}}
+        with self._mock_urlopen(data), self.assertRaises(LaunchError):
+            derive_branch_name("BAK-123", "api-key")
+
+
+# ---------------------------------------------------------------------------
+# create_worktree
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWorktree(TestCase):
+    """Tests for create_worktree."""
+
+    def test_creates_worktree_and_returns_path(self, tmp_path: Path | None = None) -> None:
+        repo_root = Path("/repo/main")
+        branch_name = "bak-123-my-feature"
+        template = "../{repo}-{branch}"
+        prefix = "zing/"
+
+        with patch("zing_ai.launch.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock()
+            result = create_worktree(repo_root, branch_name, template, prefix)
+
+        expected_path = (repo_root / "../main-bak-123-my-feature").resolve()
+        self.assertEqual(result, expected_path)
+
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args[0][0]
+        self.assertEqual(call_args[0], "git")
+        self.assertEqual(call_args[1], "worktree")
+        self.assertEqual(call_args[2], "add")
+        self.assertEqual(call_args[3], "-b")
+        self.assertEqual(call_args[4], "zing/bak-123-my-feature")
+        self.assertEqual(call_args[5], str(expected_path))
+
+    def test_raises_on_git_failure(self) -> None:
+        with (
+            patch(
+                "zing_ai.launch.subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "git", stderr="already exists"),
+            ),
+            self.assertRaises(LaunchError),
+        ):
+            create_worktree(Path("/repo"), "feat", "../{repo}-{branch}", "zing/")
+
+    def test_path_formatting_with_slash_in_branch(self) -> None:
+        """Template substitution uses the full branch_name including slashes."""
+        repo_root = Path("/repo/myproject")
+        with patch("zing_ai.launch.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock()
+            result = create_worktree(repo_root, "bak-42-fix", "../{repo}-{branch}", "")
+        expected = (repo_root / "../myproject-bak-42-fix").resolve()
+        self.assertEqual(result, expected)
+
+
+# ---------------------------------------------------------------------------
+# checkout_pr_branch
+# ---------------------------------------------------------------------------
+
+
+class TestCheckoutPrBranch(TestCase):
+    """Tests for checkout_pr_branch."""
+
+    def test_creates_worktree_on_existing_branch(self) -> None:
+        repo_root = Path("/repo/main")
+        branch = "origin/pr-branch"
+        template = "../{repo}-{branch}"
+
+        with patch("zing_ai.launch.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock()
+            result = checkout_pr_branch(repo_root, branch, template)
+
+        expected_path = (repo_root / f"../main-{branch}").resolve()
+        self.assertEqual(result, expected_path)
+
+        call_args = mock_run.call_args[0][0]
+        # Should NOT have '-b' flag
+        self.assertNotIn("-b", call_args)
+        self.assertIn("add", call_args)
+        self.assertIn(branch, call_args)
+
+    def test_raises_on_git_failure(self) -> None:
+        with (
+            patch(
+                "zing_ai.launch.subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "git", stderr="branch not found"),
+            ),
+            self.assertRaises(LaunchError),
+        ):
+            checkout_pr_branch(Path("/repo"), "missing-branch", "../{repo}-{branch}")
+
+
+# ---------------------------------------------------------------------------
+# rollback_worktree
+# ---------------------------------------------------------------------------
+
+
+class TestRollbackWorktree(TestCase):
+    """Tests for rollback_worktree."""
+
+    def test_runs_correct_command(self) -> None:
+        worktree_path = Path("/repo/worktrees/feature")
+        with patch("zing_ai.launch.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock()
+            rollback_worktree(worktree_path)
+
+        call_args = mock_run.call_args[0][0]
+        self.assertEqual(call_args, ["git", "worktree", "remove", "--force", str(worktree_path)])
+
+    def test_raises_on_git_failure(self) -> None:
+        with (
+            patch(
+                "zing_ai.launch.subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "git", stderr="not a worktree"),
+            ),
+            self.assertRaises(LaunchError),
+        ):
+            rollback_worktree(Path("/repo/worktrees/gone"))
+
+
+# ---------------------------------------------------------------------------
+# run_init_script
+# ---------------------------------------------------------------------------
+
+
+class TestRunInitScript(TestCase):
+    """Tests for run_init_script."""
+
+    def test_skips_when_script_does_not_exist(self, tmp_path: Path | None = None) -> None:
+        """No subprocess call when the init script is absent."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as repo_dir:
+            repo_root = Path(repo_dir)
+            with patch("zing_ai.launch.subprocess.run") as mock_run:
+                run_init_script(repo_root, ".zing-init.sh", Path("/worktree"), "my-branch")
+            mock_run.assert_not_called()
+
+    def test_runs_script_with_correct_env_vars(self) -> None:
+        """Script is invoked from worktree dir with the correct env vars."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as repo_dir:
+            repo_root = Path(repo_dir)
+            script = repo_root / ".zing-init.sh"
+            script.write_text("#!/bin/sh\necho hi\n")
+
+            worktree_path = Path("/tmp/worktree")
+            branch = "zing/bak-123"
+
+            with patch("zing_ai.launch.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock()
+                run_init_script(repo_root, ".zing-init.sh", worktree_path, branch)
+
+            mock_run.assert_called_once()
+            kwargs = mock_run.call_args[1]
+            env = kwargs["env"]
+            self.assertEqual(env["ZING_BRANCH"], branch)
+            self.assertEqual(env["ZING_WORKTREE_PATH"], str(worktree_path))
+            self.assertEqual(env["ZING_SPEC_FILE"], "")
+            self.assertEqual(env["ZING_SESSION_ID"], "")
+            self.assertEqual(kwargs["cwd"], worktree_path)
+
+    def test_raises_on_script_failure(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as repo_dir:
+            repo_root = Path(repo_dir)
+            script = repo_root / ".zing-init.sh"
+            script.write_text("#!/bin/sh\nexit 1\n")
+
+            with (
+                patch(
+                    "zing_ai.launch.subprocess.run",
+                    side_effect=subprocess.CalledProcessError(1, ".zing-init.sh", stderr="failed"),
+                ),
+                self.assertRaises(LaunchError),
+            ):
+                run_init_script(repo_root, ".zing-init.sh", Path("/wt"), "branch")
+
+
+# ---------------------------------------------------------------------------
+# move_ticket_in_progress
+# ---------------------------------------------------------------------------
+
+
+class TestMoveTicketInProgress(TestCase):
+    """Tests for move_ticket_in_progress."""
+
+    def _make_urlopen_sequence(self, responses: list[dict]):
+        """Return a side_effect list for sequential urllib.request.urlopen calls."""
+        mocks = []
+        for data in responses:
+            m = MagicMock()
+            m.read.return_value = json.dumps(data).encode()
+            m.__enter__ = lambda s: s
+            m.__exit__ = MagicMock(return_value=False)
+            mocks.append(m)
+        return mocks
+
+    def test_moves_ticket_in_progress(self) -> None:
+        responses = [
+            # Step 1: fetch team
+            {"data": {"issue": {"id": "issue-uuid", "team": {"id": "team-uuid"}}}},
+            # Step 2: fetch workflow state
+            {"data": {"workflowStates": {"nodes": [{"id": "state-uuid"}]}}},
+            # Step 3: update issue
+            {"data": {"issueUpdate": {"success": True}}},
+        ]
+        mocks = self._make_urlopen_sequence(responses)
+        with patch("zing_ai.launch.urllib.request.urlopen", side_effect=mocks):
+            # Should not raise
+            move_ticket_in_progress("BAK-123", "api-key")
+
+    def test_raises_when_team_not_found(self) -> None:
+        responses = [
+            {"data": {"issue": None}},
+        ]
+        mocks = self._make_urlopen_sequence(responses)
+        with (
+            patch("zing_ai.launch.urllib.request.urlopen", side_effect=mocks),
+            self.assertRaises(LaunchError),
+        ):
+            move_ticket_in_progress("BAK-999", "api-key")
+
+    def test_raises_when_no_in_progress_state(self) -> None:
+        responses = [
+            {"data": {"issue": {"id": "issue-uuid", "team": {"id": "team-uuid"}}}},
+            {"data": {"workflowStates": {"nodes": []}}},
+        ]
+        mocks = self._make_urlopen_sequence(responses)
+        with (
+            patch("zing_ai.launch.urllib.request.urlopen", side_effect=mocks),
+            self.assertRaises(LaunchError),
+        ):
+            move_ticket_in_progress("BAK-123", "api-key")
+
+    def test_raises_when_update_fails(self) -> None:
+        responses = [
+            {"data": {"issue": {"id": "issue-uuid", "team": {"id": "team-uuid"}}}},
+            {"data": {"workflowStates": {"nodes": [{"id": "state-uuid"}]}}},
+            {"data": {"issueUpdate": {"success": False}}},
+        ]
+        mocks = self._make_urlopen_sequence(responses)
+        with (
+            patch("zing_ai.launch.urllib.request.urlopen", side_effect=mocks),
+            self.assertRaises(LaunchError),
+        ):
+            move_ticket_in_progress("BAK-123", "api-key")
+
+
+# ---------------------------------------------------------------------------
+# create_mcp_session
+# ---------------------------------------------------------------------------
+
+
+class TestCreateMcpSession(TestCase):
+    """Tests for create_mcp_session."""
+
+    def test_posts_correct_payload(self) -> None:
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = json.dumps({"result": "ok"}).encode()
+        resp_mock.__enter__ = lambda s: s
+        resp_mock.__exit__ = MagicMock(return_value=False)
+
+        with patch("zing_ai.launch.urllib.request.urlopen", return_value=resp_mock) as mock_open:
+            create_mcp_session(
+                server_url="http://localhost:9876/mcp",
+                session_id="sess-abc",
+                title="My session",
+                ticket_id="BAK-42",
+                worktree_path="/tmp/wt",
+                skill="new",
+            )
+
+        # Inspect the Request object passed to urlopen
+        req = mock_open.call_args[0][0]
+        body = json.loads(req.data.decode())
+        self.assertEqual(body["method"], "tools/call")
+        params = body["params"]
+        self.assertEqual(params["name"], "session_create")
+        args = params["arguments"]
+        self.assertEqual(args["session_id"], "sess-abc")
+        self.assertEqual(args["ticket_id"], "BAK-42")
+        self.assertEqual(args["type"], "ClaudeCodeSession")
+        self.assertEqual(args["worktree_path"], "/tmp/wt")
+
+    def test_omits_optional_fields_when_none(self) -> None:
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = json.dumps({}).encode()
+        resp_mock.__enter__ = lambda s: s
+        resp_mock.__exit__ = MagicMock(return_value=False)
+
+        with patch("zing_ai.launch.urllib.request.urlopen", return_value=resp_mock) as mock_open:
+            create_mcp_session(
+                server_url="http://localhost:9876/mcp",
+                session_id="sess-xyz",
+                title="Minimal",
+                ticket_id="BAK-1",
+                worktree_path=None,
+                skill=None,
+            )
+
+        req = mock_open.call_args[0][0]
+        body = json.loads(req.data.decode())
+        args = body["params"]["arguments"]
+        self.assertNotIn("worktree_path", args)
+        self.assertNotIn("skill", args)
+
+
+# ---------------------------------------------------------------------------
+# detect_action
+# ---------------------------------------------------------------------------
+
+
+class TestDetectAction(TestCase):
+    """Tests for detect_action."""
+
+    def _mock_urlopen(self, response_data):
+        resp_mock = MagicMock()
+        resp_mock.read.return_value = json.dumps(response_data).encode()
+        resp_mock.__enter__ = lambda s: s
+        resp_mock.__exit__ = MagicMock(return_value=False)
+        return patch("zing_ai.launch.urllib.request.urlopen", return_value=resp_mock)
+
+    def test_returns_resume_when_session_found(self) -> None:
+        sessions = [
+            {"type": "ClaudeCodeSession", "ticket_id": "BAK-123", "session_id": "sess-abc"},
+            {"type": "ReviewSession", "ticket_id": "BAK-123", "session_id": "sess-xyz"},
+        ]
+        with self._mock_urlopen({"result": sessions}):
+            action, sid = detect_action("BAK-123", "http://localhost:9876/mcp")
+        self.assertEqual(action, "resume")
+        self.assertEqual(sid, "sess-abc")
+
+    def test_returns_new_when_no_matching_session(self) -> None:
+        sessions = [
+            {"type": "ClaudeCodeSession", "ticket_id": "BAK-999", "session_id": "sess-other"},
+        ]
+        with self._mock_urlopen({"result": sessions}):
+            action, sid = detect_action("BAK-123", "http://localhost:9876/mcp")
+        self.assertEqual(action, "new")
+        self.assertIsNone(sid)
+
+    def test_returns_new_when_session_list_empty(self) -> None:
+        with self._mock_urlopen({"result": []}):
+            action, sid = detect_action("BAK-123", "http://localhost:9876/mcp")
+        self.assertEqual(action, "new")
+        self.assertIsNone(sid)
+
+    def test_handles_flat_list_response(self) -> None:
+        sessions = [
+            {"type": "ClaudeCodeSession", "ticket_id": "BAK-5", "session_id": "sess-flat"},
+        ]
+        with self._mock_urlopen(sessions):
+            action, sid = detect_action("BAK-5", "http://localhost:9876/mcp")
+        self.assertEqual(action, "resume")
+        self.assertEqual(sid, "sess-flat")
+
+
+# ---------------------------------------------------------------------------
+# build_claude_args
+# ---------------------------------------------------------------------------
+
+
+class TestBuildClaudeArgs(TestCase):
+    """Tests for build_claude_args."""
+
+    def test_new_ticket_session(self) -> None:
+        args = build_claude_args("new", "BAK-123", "sess-abc", "my session")
+        self.assertEqual(
+            args,
+            ["claude", "/zing:new BAK-123", "--session-id", "sess-abc", "--name", "my session"],
+        )
+
+    def test_pr_audit_session(self) -> None:
+        args = build_claude_args("pr-audit", None, "sess-xyz", "pr session")
+        self.assertEqual(
+            args,
+            ["claude", "/zing:pr-audit", "--session-id", "sess-xyz", "--name", "pr session"],
+        )
+
+    def test_resume_session(self) -> None:
+        args = build_claude_args("resume", "BAK-123", "sess-old", "old session")
+        self.assertEqual(args, ["claude", "--resume", "sess-old"])
+
+    def test_new_without_ticket_id(self) -> None:
+        """When ticket_id is None for a new session, omit it from the slash command."""
+        args = build_claude_args("new", None, "sess-no-ticket", "unticketed")
+        self.assertEqual(
+            args,
+            [
+                "claude",
+                "/zing:new",
+                "--session-id",
+                "sess-no-ticket",
+                "--name",
+                "unticketed",
+            ],
+        )
+
+    def test_custom_skill(self) -> None:
+        """Any skill other than 'resume' or 'pr-audit' produces a new-session argv."""
+        args = build_claude_args("build", "BAK-7", "sess-build", "build session")
+        self.assertEqual(
+            args,
+            ["claude", "/zing:new BAK-7", "--session-id", "sess-build", "--name", "build session"],
+        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,14 +8,17 @@ from pydantic import TypeAdapter, ValidationError
 
 from zing_ai.server.models import (
     Category,
+    ClaudeCodeSession,
     Complexity,
     Confidence,
     Finding,
     Notification,
+    Session,
     Severity,
     TriageFinding,
     UserResponse,
     WorkflowStep,
+    ZingSession,
 )
 
 
@@ -333,6 +336,103 @@ class TestNotificationModel(unittest.TestCase):
         data = n.model_dump()
         assert data["body"] == ""
         assert data["url"] is None
+
+
+class TestSessionDiscriminatedUnion(unittest.TestCase):
+    """Test the Session discriminated union and backward compatibility."""
+
+    _adapter = TypeAdapter(Session)
+
+    def test_old_session_json_loads_as_zing_session(self) -> None:
+        """Old session JSON without session_type defaults to ZingSession."""
+        data = {
+            "session_id": "legacy-session-abc123",
+            "title": "Legacy session",
+            "ticket_id": "ENG-42",
+            "steps": [],
+            "notifications": [],
+        }
+        session = self._adapter.validate_python(data)
+        assert isinstance(session, ZingSession)
+        assert session.session_type == "zing"
+        assert session.session_id == "legacy-session-abc123"
+        assert session.ticket_id == "ENG-42"
+
+    def test_zing_session_explicit_type(self) -> None:
+        """ZingSession with explicit session_type='zing' parses correctly."""
+        data = {
+            "session_id": "zing-session-001",
+            "title": "A zing session",
+            "session_type": "zing",
+        }
+        session = self._adapter.validate_python(data)
+        assert isinstance(session, ZingSession)
+        assert session.session_type == "zing"
+
+    def test_claude_code_session_loads_correctly(self) -> None:
+        """ClaudeCodeSession with session_type='claude_code' parses correctly."""
+        data = {
+            "session_id": "claude-session-001",
+            "title": "Claude Code session",
+            "session_type": "claude_code",
+            "ticket_id": "FRO-99",
+            "worktree_path": "/tmp/worktree",
+            "skill": "zing:build",
+        }
+        session = self._adapter.validate_python(data)
+        assert isinstance(session, ClaudeCodeSession)
+        assert session.session_type == "claude_code"
+        assert session.worktree_path == "/tmp/worktree"
+        assert session.skill == "zing:build"
+        assert session.ticket_id == "FRO-99"
+
+    def test_claude_code_session_defaults(self) -> None:
+        """ClaudeCodeSession optional fields default to None."""
+        session = ClaudeCodeSession(session_id="s1", title="T")
+        assert session.worktree_path is None
+        assert session.skill is None
+        assert session.ticket_id is None
+
+    def test_session_json_roundtrip_zing(self) -> None:
+        """ZingSession round-trips through JSON serialization."""
+        original = ZingSession(session_id="zing-rt", title="Roundtrip", ticket_id="ENG-1")
+        json_bytes = self._adapter.dump_json(original)
+        restored = self._adapter.validate_json(json_bytes)
+        assert isinstance(restored, ZingSession)
+        assert restored.session_id == "zing-rt"
+        assert restored.ticket_id == "ENG-1"
+        assert restored.session_type == "zing"
+
+    def test_session_json_roundtrip_claude_code(self) -> None:
+        """ClaudeCodeSession round-trips through JSON serialization."""
+        original = ClaudeCodeSession(
+            session_id="cc-rt",
+            title="Claude RT",
+            ticket_id="FRO-5",
+            worktree_path="/tmp/wt",
+            skill="zing:plan",
+        )
+        json_bytes = self._adapter.dump_json(original)
+        restored = self._adapter.validate_json(json_bytes)
+        assert isinstance(restored, ClaudeCodeSession)
+        assert restored.session_id == "cc-rt"
+        assert restored.worktree_path == "/tmp/wt"
+        assert restored.skill == "zing:plan"
+
+    def test_zing_session_migration_flat_findings(self) -> None:
+        """Old flat-findings format migrates to steps on ZingSession."""
+        from datetime import datetime
+
+        data = {
+            "session_id": "old-flat",
+            "title": "Old format",
+            "created_at": datetime.now().isoformat(),
+            "findings": [{"type": "text", "title": "A finding"}],
+        }
+        session = self._adapter.validate_python(data)
+        assert isinstance(session, ZingSession)
+        assert len(session.steps) == 1
+        assert session.steps[0].step_name == "review"
 
 
 if __name__ == "__main__":

--- a/tests/test_server_mcp.py
+++ b/tests/test_server_mcp.py
@@ -17,7 +17,7 @@ from zing_ai.server.mcp_tools import (
     step_log,
     step_start,
 )
-from zing_ai.server.models import ResponseAction, TriageFinding, UserResponse
+from zing_ai.server.models import ResponseAction, TriageFinding, UserResponse, ZingSession
 
 
 class TestSessionCreate(ServerTestBase):
@@ -303,6 +303,7 @@ class TestStepLog(ServerTestBase):
 
         session = self.manager.get_session("log-test")
         assert session is not None
+        assert isinstance(session, ZingSession)
         self.assertEqual(len(session.steps[0].logs), 1)
         self.assertEqual(session.steps[0].logs[0].message, "Starting build...")
 
@@ -409,6 +410,7 @@ class TestMCPFindingSubmit(ServerTestBase):
 
         session = self.manager.get_session("sf-text")
         assert session is not None
+        assert isinstance(session, ZingSession)
         self.assertEqual(len(session.steps[0].findings), 1)
         self.assertEqual(session.steps[0].findings[0].type, "text")
         self.assertEqual(session.steps[0].findings[0].title, "What do you think?")
@@ -434,6 +436,7 @@ class TestMCPFindingSubmit(ServerTestBase):
 
         session = self.manager.get_session("sf-triage-no-meta")
         assert session is not None
+        assert isinstance(session, ZingSession)
         finding = session.steps[0].findings[0]
         assert isinstance(finding, TriageFinding)
         self.assertEqual(finding.type, "triage")
@@ -510,6 +513,7 @@ class TestNotificationSend(ServerTestBase):
 
         session = self.manager.get_session("notif-opts")
         assert session is not None
+        assert isinstance(session, ZingSession)
         notification = session.notifications[-1]
         self.assertEqual(notification.title, "Deploy ready")
         self.assertEqual(notification.body, "Version 2.1 is staged")

--- a/tests/test_server_rendering.py
+++ b/tests/test_server_rendering.py
@@ -22,6 +22,7 @@ from zing_ai.server.models import (
     TextFinding,
     TriageFinding,
     WarningSign,
+    ZingSession,
 )
 from zing_ai.server.routes import finding_fragment
 from zing_ai.server.templates import render
@@ -450,7 +451,7 @@ class TestNotificationTimeline(unittest.TestCase):
 
     def _make_session(self, notifications: list[Notification] | None = None) -> Session:
         """Create a minimal Session object for template rendering."""
-        return Session(
+        return ZingSession(
             session_id="notif-test",
             title="Test Session",
             notifications=notifications or [],

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -1226,3 +1226,77 @@ class TestNotificationSSEOutput(ServerTestBase):
             ),
         )
         self.assertNotIn("new Notification(", body)
+
+
+class TestClaudeCodeSessionEndpoints(ServerTestBase):
+    """Tests for the ClaudeCodeSession REST API endpoints."""
+
+    def test_post_create_claude_code_session(self) -> None:
+        """POST /api/sessions/claude-code creates a session and returns 200."""
+        resp = self.client.post(
+            "/api/sessions/claude-code",
+            json={
+                "session_id": "cc-test-1",
+                "title": "PR #42 Review",
+                "ticket_id": "BAK-123",
+                "pr_number": 42,
+                "pr_repo": "acme/repo",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "created")
+        self.assertEqual(data["session_id"], "cc-test-1")
+
+    def test_post_duplicate_returns_400(self) -> None:
+        """POST with duplicate session_id returns 400."""
+        self.client.post(
+            "/api/sessions/claude-code",
+            json={"session_id": "cc-dup", "title": "First"},
+        )
+        resp = self.client.post(
+            "/api/sessions/claude-code",
+            json={"session_id": "cc-dup", "title": "Second"},
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_get_sessions_returns_all(self) -> None:
+        """GET /api/sessions returns all sessions."""
+        self._create_session("zing-1", "Zing Session")
+        self.client.post(
+            "/api/sessions/claude-code",
+            json={"session_id": "cc-1", "title": "Claude Session"},
+        )
+        resp = self.client.get("/api/sessions")
+        self.assertEqual(resp.status_code, 200)
+        ids = [s["session_id"] for s in resp.json()]
+        self.assertIn("zing-1", ids)
+        self.assertIn("cc-1", ids)
+
+    def test_get_sessions_filters_by_ticket_id(self) -> None:
+        """GET /api/sessions?ticket_id=X filters correctly."""
+        self.client.post(
+            "/api/sessions/claude-code",
+            json={"session_id": "cc-a", "title": "A", "ticket_id": "BAK-1"},
+        )
+        self.client.post(
+            "/api/sessions/claude-code",
+            json={"session_id": "cc-b", "title": "B", "ticket_id": "BAK-2"},
+        )
+        resp = self.client.get("/api/sessions?ticket_id=BAK-1")
+        self.assertEqual(resp.status_code, 200)
+        sessions = resp.json()
+        self.assertEqual(len(sessions), 1)
+        self.assertEqual(sessions[0]["session_id"], "cc-a")
+
+    def test_get_sessions_response_shape(self) -> None:
+        """GET /api/sessions returns fields expected by detect_action."""
+        self.client.post(
+            "/api/sessions/claude-code",
+            json={"session_id": "cc-shape", "title": "Shape", "ticket_id": "FRO-1"},
+        )
+        resp = self.client.get("/api/sessions?ticket_id=FRO-1")
+        session = resp.json()[0]
+        self.assertEqual(session["session_type"], "claude_code")
+        self.assertIn("session_id", session)
+        self.assertIn("ticket_id", session)

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 from tests.test_server_base import _STEP, ServerTestBase
 from zing_ai.server.mcp_tools import configure, review_wait
+from zing_ai.server.models import ZingSession
 from zing_ai.server.routes import _dashboard_queues, _sse_queues
 
 
@@ -72,6 +73,7 @@ class TestSaveResponse(ServerTestBase):
         )
         session = self.manager.get_session("test-session")
         assert session is not None
+        assert isinstance(session, ZingSession)
         step = session.steps[0]
         assert step.responses is not None
         self.assertEqual(step.responses[0].answer, "Saved text")
@@ -134,6 +136,7 @@ class TestSaveResponse(ServerTestBase):
         self.assertEqual(resp.json()["saved"], 1)
         session = self.manager.get_session("test-session")
         assert session is not None
+        assert isinstance(session, ZingSession)
         step = session.steps[0]
         assert step.responses is not None
         assert step.responses[0].complexity is not None
@@ -152,6 +155,7 @@ class TestSaveResponse(ServerTestBase):
         self.assertEqual(resp.status_code, 200)
         session = self.manager.get_session("test-session")
         assert session is not None
+        assert isinstance(session, ZingSession)
         step = session.steps[0]
         assert step.responses is not None
         assert step.responses[0].complexity is not None
@@ -179,6 +183,7 @@ class TestSaveResponse(ServerTestBase):
         )
         session = self.manager.get_session("test-session")
         assert session is not None
+        assert isinstance(session, ZingSession)
         step = session.steps[0]
         assert step.responses is not None
         self.assertEqual(step.responses[0].action, "accept")
@@ -198,6 +203,7 @@ class TestSaveResponse(ServerTestBase):
         )
         session = self.manager.get_session("test-session")
         assert session is not None
+        assert isinstance(session, ZingSession)
         step = session.steps[0]
         assert step.responses is not None
         self.assertEqual(step.responses[0].action, "drop")
@@ -216,6 +222,7 @@ class TestSaveResponse(ServerTestBase):
         self.assertEqual(resp.status_code, 200)
         session = self.manager.get_session("test-session")
         assert session is not None
+        assert isinstance(session, ZingSession)
         step = session.steps[0]
         # No response should have been saved since the only field was invalid
         if step.responses:
@@ -234,6 +241,7 @@ class TestSaveResponse(ServerTestBase):
         self.assertEqual(resp.status_code, 200)
         session = self.manager.get_session("test-session")
         assert session is not None
+        assert isinstance(session, ZingSession)
         step = session.steps[0]
         if step.responses:
             self.assertIsNone(step.responses[0].complexity)
@@ -329,6 +337,7 @@ class TestSubmit(ServerTestBase):
 
         session = self.manager.get_session("test-session")
         assert session is not None
+        assert isinstance(session, ZingSession)
         self.assertEqual(session.state.value, "completed")
         step = session.steps[0]
         assert step.responses is not None
@@ -368,6 +377,7 @@ class TestSubmit(ServerTestBase):
 
         session = self.manager.get_session("test-session")
         assert session is not None
+        assert isinstance(session, ZingSession)
         step = session.steps[0]
         assert step.responses is not None
         # Evaluation finding gets empty response (auto-acknowledged)
@@ -441,6 +451,7 @@ class TestSubmit(ServerTestBase):
         self.assertEqual(resp.status_code, 200)
         session = self.manager.get_session("test-session")
         assert session is not None
+        assert isinstance(session, ZingSession)
         step = session.steps[0]
         assert step.responses is not None
         self.assertEqual(step.responses[0].selected, "__other__")
@@ -477,6 +488,7 @@ class TestSubmit(ServerTestBase):
         self.assertEqual(resp.status_code, 200)
         session = self.manager.get_session("test-session")
         assert session is not None
+        assert isinstance(session, ZingSession)
         step = session.steps[0]
         assert step.responses is not None
         self.assertEqual(step.responses[0].action, "accept")
@@ -520,6 +532,7 @@ class TestSubmit(ServerTestBase):
         self.assertEqual(resp.status_code, 200)
         session = self.manager.get_session("test-session")
         assert session is not None
+        assert isinstance(session, ZingSession)
         step = session.steps[0]
         assert step.responses is not None
         self.assertEqual(step.responses[0].action, "accept")
@@ -879,6 +892,8 @@ class TestConcurrentSessions(ServerTestBase):
         session_b = self.manager.get_session("session-b")
         assert session_a is not None
         assert session_b is not None
+        assert isinstance(session_a, ZingSession)
+        assert isinstance(session_b, ZingSession)
 
         self.assertEqual(session_a.total_findings, 1)
         self.assertEqual(session_b.total_findings, 1)
@@ -1182,6 +1197,7 @@ class TestNotificationSSEOutput(ServerTestBase):
         self._create_session(session_id="empty-notif")
         session = self.manager.get_session("empty-notif")
         assert session is not None
+        assert isinstance(session, ZingSession)
         session.notifications.clear()
 
         body = asyncio.run(
@@ -1200,6 +1216,7 @@ class TestNotificationSSEOutput(ServerTestBase):
         self._create_session(session_id=session_id)
         session = self.manager.get_session(session_id)
         assert session is not None
+        assert isinstance(session, ZingSession)
         session.notifications.clear()
 
         body = asyncio.run(

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -7,7 +7,13 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from zing_ai.server.models import ResponseAction, SessionState, UserResponse, WorkflowStep
+from zing_ai.server.models import (
+    ResponseAction,
+    SessionState,
+    UserResponse,
+    WorkflowStep,
+    ZingSession,
+)
 from zing_ai.server.sessions import SessionManager
 
 _STEP = "review"
@@ -80,6 +86,7 @@ class TestSessionLifecycle(unittest.TestCase):
             zing_file=self.zing_file,
             title="New Title",
         )
+        assert isinstance(updated, ZingSession)
         assert updated.title == "New Title"
         assert updated.zing_file == self.zing_file
 
@@ -87,6 +94,7 @@ class TestSessionLifecycle(unittest.TestCase):
         reloaded = SessionManager(data_dir=self.data_dir)
         s = reloaded.get_session("s1")
         assert s is not None
+        assert isinstance(s, ZingSession)
         assert s.title == "New Title"
         assert s.zing_file == self.zing_file
 
@@ -96,11 +104,13 @@ class TestSessionLifecycle(unittest.TestCase):
 
         # Update only title
         updated = self.manager.update_session("s1", title="New Title")
+        assert isinstance(updated, ZingSession)
         assert updated.title == "New Title"
         assert updated.zing_file == self.zing_file
 
         # Update only zing_file (using setUp.py as a different valid file)
         updated2 = self.manager.update_session("s1", zing_file=self.zing_file)
+        assert isinstance(updated2, ZingSession)
         assert updated2.title == "New Title"
         assert updated2.zing_file == self.zing_file
 
@@ -173,6 +183,7 @@ class TestSessionLifecycle(unittest.TestCase):
 
         session = self.manager.get_session("s1")
         assert session is not None
+        assert isinstance(session, ZingSession)
         assert len(session.steps) == 1
         assert session.steps[0].state == SessionState.STARTED
 
@@ -204,6 +215,7 @@ class TestSessionLifecycle(unittest.TestCase):
         assert finding.type == "text"
         session = self.manager.get_session("s1")
         assert session is not None
+        assert isinstance(session, ZingSession)
         assert session.total_findings == 1
         assert len(session.steps[0].findings) == 1
 
@@ -230,6 +242,7 @@ class TestSessionLifecycle(unittest.TestCase):
         assert finding.type == "evaluation"
         session = self.manager.get_session("s1")
         assert session is not None
+        assert isinstance(session, ZingSession)
         assert session.total_findings == 1
 
     def test_add_finding_triage_without_metadata(self) -> None:
@@ -294,6 +307,7 @@ class TestSessionLifecycle(unittest.TestCase):
         )
         session = self.manager.get_session("s1")
         assert session is not None
+        assert isinstance(session, ZingSession)
         assert len(session.steps[0].findings) == 1, (
             f"Expected 1 finding after dedup, got {len(session.steps[0].findings)}"
         )
@@ -365,6 +379,7 @@ class TestSessionLifecycle(unittest.TestCase):
         # Session should NOT be completed — second step is still pending
         session = self.manager.get_session("s1")
         assert session is not None
+        assert isinstance(session, ZingSession)
         assert session.state != SessionState.COMPLETED
 
         # Complete second step
@@ -422,10 +437,12 @@ class TestConcurrentSessions(unittest.TestCase):
         s2 = self.manager.get_session("s2")
         assert s1 is not None
         assert s2 is not None
+        assert isinstance(s1, ZingSession)
+        assert isinstance(s2, ZingSession)
         assert s1.total_findings == 1
         assert s2.total_findings == 1
-        assert s1.steps[0].findings[0].type == "text"  # type: ignore[union-attr]
-        assert s2.steps[0].findings[0].type == "triage"  # type: ignore[union-attr]
+        assert s1.steps[0].findings[0].type == "text"
+        assert s2.steps[0].findings[0].type == "triage"
 
     def test_agent_completion_isolated(self) -> None:
         """Completing an agent in one session doesn't affect another."""
@@ -440,6 +457,8 @@ class TestConcurrentSessions(unittest.TestCase):
         s2 = self.manager.get_session("s2")
         assert s1 is not None
         assert s2 is not None
+        assert isinstance(s1, ZingSession)
+        assert isinstance(s2, ZingSession)
         assert s1.steps[0].state == SessionState.STARTED
         assert s2.steps[0].state == SessionState.STARTED
         assert len(s2.steps[0].agents) == 0
@@ -644,6 +663,7 @@ class TestPersistence(unittest.TestCase):
         mgr2 = SessionManager(data_dir=self.data_dir)
         session = mgr2.get_session("s1")
         assert session is not None
+        assert isinstance(session, ZingSession)
         assert session.title == "Persistent"
         assert session.total_findings == 1
         assert len(session.steps[0].agents) == 1
@@ -684,6 +704,7 @@ class TestPersistence(unittest.TestCase):
         mgr = SessionManager(data_dir=self.data_dir)
         session = mgr.get_session("old1")
         assert session is not None
+        assert isinstance(session, ZingSession)
         assert len(session.steps) == 1
         assert session.steps[0].step_name == "review"
         assert len(session.steps[0].findings) == 1
@@ -732,6 +753,7 @@ class TestWorkflowStepLooping(unittest.TestCase):
 
         session = self.manager.get_session("s1")
         assert session is not None
+        assert isinstance(session, ZingSession)
         assert len(session.steps) == 2
 
     def test_start_step_auto_completes_prior_steps(self) -> None:
@@ -741,12 +763,14 @@ class TestWorkflowStepLooping(unittest.TestCase):
 
         session = self.manager.get_session("s1")
         assert session is not None
+        assert isinstance(session, ZingSession)
         assert session.steps[0].state.value == "started"
 
         self.manager.start_step("s1", session.steps[1].step_id)
 
         session = self.manager.get_session("s1")
         assert session is not None
+        assert isinstance(session, ZingSession)
         assert session.steps[0].state.value == "completed"
         assert session.steps[1].state.value == "started"
 
@@ -761,10 +785,11 @@ class TestWorkflowStepLooping(unittest.TestCase):
 
         session = self.manager.get_session("s1")
         assert session is not None
+        assert isinstance(session, ZingSession)
         assert len(session.steps[0].findings) == 1
         assert len(session.steps[1].findings) == 1
-        assert session.steps[0].findings[0].title == "First"  # type: ignore[union-attr]
-        assert session.steps[1].findings[0].title == "Second"  # type: ignore[union-attr]
+        assert session.steps[0].findings[0].title == "First"
+        assert session.steps[1].findings[0].title == "Second"
 
 
 class TestWaitForReview(unittest.TestCase):
@@ -1120,6 +1145,7 @@ class TestAddLog(unittest.TestCase):
 
         updated_session = self.manager.get_session("s1")
         assert updated_session is not None
+        assert isinstance(updated_session, ZingSession)
         updated_step = updated_session.steps[0]
         assert len(updated_step.logs) == 3
 
@@ -1169,6 +1195,7 @@ class TestNotifications(unittest.TestCase):
         notif = self.manager.add_notification("s1", "Alert", body="Details", url="/s1")
         session = self.manager.get_session("s1")
         assert session is not None
+        assert isinstance(session, ZingSession)
         # create_session adds one auto-notification, add_notification adds another
         assert len(session.notifications) == 2
         assert session.notifications[-1].title == "Alert"
@@ -1184,6 +1211,7 @@ class TestNotifications(unittest.TestCase):
         mgr2 = SessionManager(data_dir=self.data_dir)
         session = mgr2.get_session("s1")
         assert session is not None
+        assert isinstance(session, ZingSession)
         titles = [n.title for n in session.notifications]
         assert "Persisted alert" in titles
 
@@ -1203,6 +1231,7 @@ class TestNotifications(unittest.TestCase):
 
         session = self.manager.get_session("s1")
         assert session is not None
+        assert isinstance(session, ZingSession)
         titles = [n.title for n in session.notifications]
         assert f"Review ready: {_STEP}" in titles
 
@@ -1218,6 +1247,7 @@ class TestNotifications(unittest.TestCase):
         mgr2 = SessionManager(data_dir=self.data_dir)
         session = mgr2.get_session("s1")
         assert session is not None
+        assert isinstance(session, ZingSession)
         titles = [n.title for n in session.notifications]
         assert "New session: Test" in titles
         assert f"Review ready: {_STEP}" in titles

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1269,5 +1269,81 @@ class TestNotifications(unittest.TestCase):
         assert len(matching) == 1
 
 
+class TestClaudeCodeSession(unittest.TestCase):
+    """Tests for ClaudeCodeSession creation and persistence."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.data_dir = Path(self._tmp.name)
+        self.manager = SessionManager(data_dir=self.data_dir)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_create_claude_code_session(self) -> None:
+        """Creating a ClaudeCodeSession returns correct fields."""
+        from zing_ai.server.models import ClaudeCodeSession
+
+        session = self.manager.create_claude_code_session(
+            session_id="cc-1",
+            title="PR #42 Review",
+            ticket_id="BAK-123",
+            worktree_path="/tmp/worktree",
+            skill="pr-audit",
+            pr_number=42,
+            pr_repo="acme/repo",
+        )
+        assert isinstance(session, ClaudeCodeSession)
+        assert session.session_id == "cc-1"
+        assert session.title == "PR #42 Review"
+        assert session.ticket_id == "BAK-123"
+        assert session.worktree_path == "/tmp/worktree"
+        assert session.skill == "pr-audit"
+        assert session.pr_number == 42
+        assert session.pr_repo == "acme/repo"
+        assert session.state == SessionState.STARTED
+
+    def test_create_duplicate_raises(self) -> None:
+        """Duplicate session_id raises ValueError."""
+        self.manager.create_claude_code_session(session_id="cc-dup", title="First")
+        with self.assertRaises(ValueError, msg="Session already exists"):
+            self.manager.create_claude_code_session(session_id="cc-dup", title="Second")
+
+    def test_invalid_session_id_raises(self) -> None:
+        """Invalid session_id is rejected."""
+        with self.assertRaises(ValueError):
+            self.manager.create_claude_code_session(session_id="../bad", title="Bad")
+
+    def test_persisted_and_reloaded(self) -> None:
+        """ClaudeCodeSession survives round-trip through disk persistence."""
+        from zing_ai.server.models import ClaudeCodeSession
+
+        self.manager.create_claude_code_session(
+            session_id="cc-persist",
+            title="Persist Test",
+            ticket_id="FRO-99",
+            pr_number=99,
+            pr_repo="acme/frontend",
+        )
+        # Create a new manager that loads from the same directory
+        manager2 = SessionManager(data_dir=self.data_dir)
+        sessions = manager2.list_sessions()
+        matching = [s for s in sessions if s.session_id == "cc-persist"]
+        assert len(matching) == 1
+        loaded = matching[0]
+        assert isinstance(loaded, ClaudeCodeSession)
+        assert loaded.title == "Persist Test"
+        assert loaded.ticket_id == "FRO-99"
+        assert loaded.pr_number == 99
+        assert loaded.pr_repo == "acme/frontend"
+
+    def test_listed_in_list_sessions(self) -> None:
+        """ClaudeCodeSession appears in list_sessions()."""
+        self.manager.create_claude_code_session(session_id="cc-list", title="List Test")
+        sessions = self.manager.list_sessions()
+        ids = [s.session_id for s in sessions]
+        assert "cc-list" in ids
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add `zing-ai launch <ticket-or-PR-URL>` CLI command that creates git worktrees, registers sessions on the Zing server, and execs into Claude Code with the appropriate slash command
- Refactor `Session` model into a discriminated union (`ZingSession | ClaudeCodeSession`) with backward-compatible deserialization
- Link sessions to command center kanban cards by ticket ID or PR number, including title-parsing fallback for ZingSession
- Expand card inclusion and "done" classification to account for users who submitted reviews (not just requested reviewers)
- Add launch buttons, session indicators, and "Ready to merge" section to the command center UI

## What's in the diff

- **`launch.py`** (new): Pure functions for PR URL parsing, git worktree management, Linear API integration, session creation via REST, and Claude argument building
- **`cli.py`**: `launch` command orchestrating the ticket and PR flows, with `--skill` and `--resume/--no-resume` flags
- **`models.py`**: `SessionBase` → `ZingSession | ClaudeCodeSession` discriminated union with `_session_discriminator` for backward compat
- **`command_center.py`**: PR-number-based session linking (`_session_pr_number`), reviewer-aware card inclusion/done classification, repo-scoped orphan PR card keys
- **`sessions.py`**: `create_claude_code_session()`, type-narrowed step/notification methods
- **`routes.py`**: `POST /api/sessions/claude-code`, `GET /api/sessions` REST endpoints
- **Templates**: Launch buttons (clipboard-copy), session type indicators (blue for Claude Code, clickable for Zing), Done column with "Ready to merge" grouping
- **`github_client.py`**: Fetch `latestReviews` to populate `pr.reviewers` field

## Review findings addressed

Code review surfaced 9 findings (6 code fixes, 3 test gaps):
- Linear API key read moved inside ticket branch (PR flows no longer fail without lr config)
- Worktree reuse now verified with `git rev-parse`
- GET /api/sessions filters before serializing
- Ticket regex unified to shared `TICKET_ID_PATTERN`
- `_card_most_recent_activity` includes `created_at` for all session types
- Orphan PR card keys include repo to prevent cross-repo collision
- `ClaudeCodeSession` excluded from `_has_active_session` (display-only)
- Added 20 new tests covering SessionManager, REST endpoints, and command_center functions

## Test plan

- [x] All 561 unit tests pass
- [x] Ruff, pyright, pyleft pass
- [x] Pre-push hooks (including Playwright UI tests) pass
- [ ] Manual: `zing-ai launch BAK-XXX` creates worktree + session, execs into Claude
- [ ] Manual: `zing-ai launch https://github.com/.../pull/N` creates review session linked to PR card
- [ ] Manual: Command center shows session indicators on cards, launch buttons work

---

🤖 Created with [Zing](https://github.com/Farmer-Pete/Zing)