### PR TITLE
Add Command Center attention system with drawer and card strips

### DIFF
--- a/src/zing_ai/hooks/notify-zing.sh
+++ b/src/zing_ai/hooks/notify-zing.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+input=$(cat)
+question=$(echo "$input" | jq -r '.tool_input.question // (.tool_input.questions[0] // empty)' 2>/dev/null)
+session_id=$(echo "$input" | jq -r '.session_id // empty' 2>/dev/null)
+[ -z "$question" ] && exit 0
+payload=$(jq -n --arg sid "$session_id" --arg q "$question" '{session_id: $sid, question: $q}')
+curl -s -X POST http://127.0.0.1:9876/command-center/session-question \
+  -H "Content-Type: application/json" \
+  -d "$payload" \
+  -m 2 >/dev/null 2>&1
+exit 0

--- a/src/zing_ai/installer.py
+++ b/src/zing_ai/installer.py
@@ -115,6 +115,93 @@ def install_claude(target_dir: Path | None = None, config: Config | None = None)
     )
 
     register_mcp_server("claude")
+    install_claude_hooks()
+
+
+def install_claude_hooks(hooks_dir: Path | None = None, settings_path: Path | None = None) -> None:
+    """Install the notify-zing.sh hook and register it in Claude Code settings.
+
+    Creates ``~/.claude/hooks/`` if it doesn't exist, copies the bundled
+    ``notify-zing.sh`` script into it (making it executable), and merges the
+    ``PreToolUse`` hook entry for ``AskUserQuestion`` into
+    ``~/.claude/settings.json``.
+
+    The operation is idempotent — running it again will not duplicate the hook
+    entry in settings.json.
+
+    Parameters
+    ----------
+    hooks_dir:
+        Override for ``~/.claude/hooks/``.  Useful for testing.
+    settings_path:
+        Override for ``~/.claude/settings.json``.  Useful for testing.
+    """
+    if hooks_dir is None:
+        hooks_dir = Path.home() / ".claude" / "hooks"
+    if settings_path is None:
+        settings_path = Path.home() / ".claude" / "settings.json"
+
+    logger.info("Installing Claude hooks to %s", hooks_dir)
+
+    # -- 1. Ensure hooks directory exists -------------------------------------
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    # -- 2. Copy notify-zing.sh -----------------------------------------------
+    src_hook = importlib.resources.files("zing_ai").joinpath("hooks").joinpath("notify-zing.sh")
+    dst_hook = hooks_dir / "notify-zing.sh"
+    dst_hook.write_bytes(src_hook.read_bytes())
+    # Make it executable (owner, group, others)
+    current_mode = dst_hook.stat().st_mode
+    dst_hook.chmod(current_mode | 0o111)
+    logger.debug("Installed hook script: %s", dst_hook)
+
+    # -- 3. Merge PreToolUse entry into settings.json -------------------------
+    _merge_pretooluse_hook(settings_path)
+
+
+def _merge_pretooluse_hook(settings_path: Path) -> None:
+    """Merge the AskUserQuestion PreToolUse hook entry into settings.json.
+
+    Reads the existing settings file (or starts with an empty dict), checks
+    whether a ``PreToolUse`` entry with ``matcher: "AskUserQuestion"`` already
+    exists, and only appends it if missing.  Existing hooks are always
+    preserved.
+    """
+    settings: dict = {}
+    if settings_path.exists():
+        try:
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Could not read existing settings.json: %s", exc)
+            settings = {}
+
+    hooks_section = settings.setdefault("hooks", {})
+    pretooluse_list = hooks_section.setdefault("PreToolUse", [])
+
+    # Check for an existing entry with matcher "AskUserQuestion".
+    matcher = "AskUserQuestion"
+    for entry in pretooluse_list:
+        if isinstance(entry, dict) and entry.get("matcher") == matcher:
+            logger.debug("PreToolUse hook for %r already registered — skipping", matcher)
+            return
+
+    # Append the new entry.
+    pretooluse_list.append(
+        {
+            "matcher": matcher,
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "~/.claude/hooks/notify-zing.sh",
+                    "timeout": 5,
+                }
+            ],
+        }
+    )
+
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    logger.debug("Registered PreToolUse hook for %r in %s", matcher, settings_path)
 
 
 def install_opencode(target_dir: Path | None = None, config: Config | None = None) -> None:

--- a/src/zing_ai/server/app.py
+++ b/src/zing_ai/server/app.py
@@ -285,6 +285,7 @@ def create_app(
             notif_id = event_type.split(":", 1)[1]
             _notify_sse_connections(session_id, f"notification:{notif_id}")
             _notify_dashboard_connections(f"notification:{notif_id}", session_id=session_id)
+            _notify_cc_connections("board_changed")
             return
         if event_type in sse_events:
             _notify_sse_connections(session_id, sse_events[event_type])

--- a/src/zing_ai/server/attention.py
+++ b/src/zing_ai/server/attention.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal
 
+from zing_ai.server.command_center import _ensure_utc
 from zing_ai.server.models import ClaudeCodeSession, Session, SessionState, ZingSession
 
 
@@ -37,12 +38,13 @@ def build_attention_queue(sessions: list[Session], now: datetime) -> list[Attent
     Returns items sorted by wait_seconds descending (longest wait first).
     """
     items: list[AttentionItem] = []
+    now = _ensure_utc(now)
 
     for session in sessions:
         if isinstance(session, ZingSession):
             for step in session.steps:
                 if step.state == SessionState.READY:
-                    wait_seconds = int((now - step.created_at).total_seconds())
+                    wait_seconds = int((now - _ensure_utc(step.created_at)).total_seconds())
                     action_type: Literal["findings", "attach", "questions"] = (
                         "questions" if step.step_name == "plan" else "findings"
                     )
@@ -64,7 +66,7 @@ def build_attention_queue(sessions: list[Session], now: datetime) -> list[Attent
         elif isinstance(session, ClaudeCodeSession):
             notification = session.pending_question
             if notification is not None:
-                wait_seconds = int((now - notification.created_at).total_seconds())
+                wait_seconds = int((now - _ensure_utc(notification.created_at)).total_seconds())
                 items.append(
                     AttentionItem(
                         action_type="attach",

--- a/src/zing_ai/server/attention.py
+++ b/src/zing_ai/server/attention.py
@@ -1,0 +1,83 @@
+"""Attention queue logic for the Command Center."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+from zing_ai.server.models import ClaudeCodeSession, Session, SessionState, ZingSession
+
+
+@dataclass
+class AttentionItem:
+    """An item requiring user attention in the Command Center."""
+
+    action_type: Literal["findings", "attach", "questions"]
+    session_id: str
+    ticket_id: str | None
+    title: str
+    description: str  # "5 findings from build-audit" or question preview
+    step_name: str | None
+    finding_count: int
+    wait_seconds: int  # seconds since step became READY or notification was created
+    card_key: str | None  # for linking to the card
+
+
+def build_attention_queue(sessions: list[Session], now: datetime) -> list[AttentionItem]:
+    """Build a list of items requiring user attention, sorted by wait time descending.
+
+    For each ZingSession: if any step is in READY state, creates an AttentionItem.
+    Classifies by step name: action_type="questions" if step_name == "plan",
+    otherwise action_type="findings".
+
+    For each ClaudeCodeSession: if has pending_question (notification with
+    answered_at is None), creates an AttentionItem with action_type="attach".
+
+    Returns items sorted by wait_seconds descending (longest wait first).
+    """
+    items: list[AttentionItem] = []
+
+    for session in sessions:
+        if isinstance(session, ZingSession):
+            for step in session.steps:
+                if step.state == SessionState.READY:
+                    wait_seconds = int((now - step.created_at).total_seconds())
+                    action_type: Literal["findings", "attach", "questions"] = (
+                        "questions" if step.step_name == "plan" else "findings"
+                    )
+                    finding_count = len(step.findings)
+                    description = f"{finding_count} findings from {step.step_name}"
+                    items.append(
+                        AttentionItem(
+                            action_type=action_type,
+                            session_id=session.session_id,
+                            ticket_id=session.ticket_id,
+                            title=session.title,
+                            description=description,
+                            step_name=step.step_name,
+                            finding_count=finding_count,
+                            wait_seconds=wait_seconds,
+                            card_key=session.session_id,
+                        )
+                    )
+        elif isinstance(session, ClaudeCodeSession):
+            notification = session.pending_question
+            if notification is not None:
+                wait_seconds = int((now - notification.created_at).total_seconds())
+                items.append(
+                    AttentionItem(
+                        action_type="attach",
+                        session_id=session.session_id,
+                        ticket_id=session.ticket_id,
+                        title=session.title,
+                        description=notification.body,
+                        step_name=None,
+                        finding_count=0,
+                        wait_seconds=wait_seconds,
+                        card_key=session.session_id,
+                    )
+                )
+
+    items.sort(key=lambda item: item.wait_seconds, reverse=True)
+    return items

--- a/src/zing_ai/server/command_center.py
+++ b/src/zing_ai/server/command_center.py
@@ -839,6 +839,83 @@ def generate_standup(view: KanbanView, current_username: str) -> str:
     return "\n\n".join(sections)
 
 
+def build_session_phases(session: ZingSession) -> list[dict]:
+    """Build a list of phase segments for a session's mini timeline.
+
+    Each segment has a ``phase`` key (e.g. ``"plan"``, ``"build"``, ``"wait"``)
+    and a ``flex`` key — a relative weight computed from the duration of the
+    step compared to the total session duration.
+
+    The phase name maps to a CSS modifier class on `.css-seg`:
+    - ``"plan"``  → ``.css-p``  (orange)
+    - ``"audit"`` → ``.css-a``  (amber)
+    - ``"build"`` → ``.css-b``  (purple)
+    - ``"ready"`` → ``.css-r``  (cyan)
+    - ``"wait"``  → ``.css-w``  (gray)
+    - ``"done"``  → ``.css-u``  (green)
+
+    Uses adjacent-step timestamp heuristic: each step's duration is estimated
+    as the time between its ``created_at`` and the next step's ``created_at``
+    (or ``now`` for the last step).  Steps with zero or negative duration are
+    assigned a minimum flex of 0.1 so they still appear.
+
+    Returns an empty list when the session has no steps.
+    """
+    if not session.steps:
+        return []
+
+    now = datetime.now(UTC)
+
+    _PHASE_MAP: dict[str, str] = {
+        "plan": "plan",
+        "plan-audit": "audit",
+        "build": "build",
+        "build-audit": "audit",
+        "pr-audit": "audit",
+        "custom-audit": "audit",
+        "ready": "ready",
+    }
+
+    segments: list[dict] = []
+    total_seconds = 0.0
+
+    for i, step in enumerate(session.steps):
+        step_start = _ensure_utc(step.created_at)
+        if i + 1 < len(session.steps):
+            step_end = _ensure_utc(session.steps[i + 1].created_at)
+        else:
+            step_end = now
+
+        duration = max((step_end - step_start).total_seconds(), 0.0)
+        total_seconds += duration
+
+        # Determine phase name from step_name
+        phase = _PHASE_MAP.get(step.step_name, "build")
+        segments.append({"phase": phase, "duration": duration})
+
+    # Convert durations to flex values (normalised so max ≈ 10)
+    if total_seconds <= 0:
+        # Fallback: equal weights
+        return [{"phase": s["phase"], "flex": 1.0} for s in segments]
+
+    scale = 10.0 / total_seconds
+    result: list[dict] = []
+    for s in segments:
+        flex = max(round(s["duration"] * scale, 1), 0.1)
+        result.append({"phase": s["phase"], "flex": flex})
+
+    # Add a trailing "wait" segment if the session state is READY or STARTED
+    # (i.e., still running) — this represents the current waiting period.
+    if session.state in (SessionState.READY, SessionState.STARTED):
+        last_step_end = _ensure_utc(session.steps[-1].created_at)
+        waiting_secs = max((now - last_step_end).total_seconds(), 0.0)
+        if waiting_secs > 0:
+            wait_flex = max(round(waiting_secs * scale, 1), 0.2)
+            result.append({"phase": "wait", "flex": wait_flex})
+
+    return result
+
+
 def get_live_sessions() -> set[str]:
     """Return the set of live Zellij session names with the zing-- prefix."""
     try:

--- a/src/zing_ai/server/models.py
+++ b/src/zing_ai/server/models.py
@@ -358,6 +358,7 @@ class ClaudeCodeSession(SessionBase):
     pr_number: int | None = None
     pr_repo: str | None = None
     terminal_session: str | None = None
+    notifications: list[Notification] = Field(default_factory=list)
     _session_alive: bool = PrivateAttr(default=False)
 
     @model_validator(mode="before")
@@ -367,6 +368,13 @@ class ClaudeCodeSession(SessionBase):
         if isinstance(data, dict) and "tmux_session" in data and "terminal_session" not in data:
             data["terminal_session"] = data.pop("tmux_session")
         return data
+
+    @property
+    def pending_question(self) -> Notification | None:
+        """Return the last notification with no corresponding response, or None."""
+        if not self.notifications:
+            return None
+        return self.notifications[-1]
 
     @property
     def state(self) -> SessionState:

--- a/src/zing_ai/server/models.py
+++ b/src/zing_ai/server/models.py
@@ -195,6 +195,7 @@ class Notification(BaseModel):
     body: str = ""
     url: str | None = None
     created_at: datetime = Field(default_factory=datetime.now)
+    answered_at: datetime | None = None
 
 
 class ResponseAction(StrEnum):
@@ -371,10 +372,8 @@ class ClaudeCodeSession(SessionBase):
 
     @property
     def pending_question(self) -> Notification | None:
-        """Return the last notification with no corresponding response, or None."""
-        if not self.notifications:
-            return None
-        return self.notifications[-1]
+        """Return the last unanswered notification, or None."""
+        return next((n for n in reversed(self.notifications) if n.answered_at is None), None)
 
     @property
     def state(self) -> SessionState:

--- a/src/zing_ai/server/routes_command_center.py
+++ b/src/zing_ai/server/routes_command_center.py
@@ -33,9 +33,9 @@ from zing_ai.launch import (
     move_ticket_in_progress,
     rollback_worktree,
 )
-from zing_ai.server.attention import build_attention_queue
+from zing_ai.server.attention import AttentionItem, build_attention_queue
 from zing_ai.server.command_center import aggregate, generate_standup, infer_repo_for_ticket
-from zing_ai.server.models import ClaudeCodeSession
+from zing_ai.server.models import ClaudeCodeSession, ZingSession
 from zing_ai.server.models_external import KanbanView
 from zing_ai.server.templates import render, render_markdown
 
@@ -729,3 +729,153 @@ async def session_question(request: Request) -> JSONResponse:
         return JSONResponse({"status": "ignored"})
     manager.add_notification(session_id, title="Input needed", body=question)
     return JSONResponse({"status": "ok"})
+
+
+# ---------------------------------------------------------------------------
+# Review drawer
+# ---------------------------------------------------------------------------
+
+
+def _format_wait_label(seconds: int) -> str:
+    """Return a compact wait-time string: '42s', '5m', '2h'."""
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    return f"{seconds // 3600}h"
+
+
+def build_drawer_context(
+    session_id: str,
+    manager: object,
+    attention_queue: list[AttentionItem],
+) -> dict:
+    """Build template context for the review drawer.
+
+    Args:
+        session_id: The session to open in the drawer.
+        manager: The session manager (app.state.session_manager).
+        attention_queue: Current attention queue from build_attention_queue().
+
+    Returns:
+        A dict with keys: session, steps, current_step, mode, queue_position,
+        queue_total, queue_items, next_session_id, prev_session_id,
+        waiting_label, notification_body, notification.
+    """
+    session = manager.get_session(session_id)  # type: ignore[union-attr]
+    if session is None:
+        return {}
+
+    # Find this session in the attention queue to determine position.
+    queue_index = next(
+        (i for i, item in enumerate(attention_queue) if item.session_id == session_id),
+        None,
+    )
+
+    queue_total = len(attention_queue)
+    queue_position = (queue_index + 1) if queue_index is not None else 1
+
+    # Items after this one in the queue.
+    queue_items = attention_queue[queue_index + 1 :] if queue_index is not None else []
+
+    next_session_id: str | None = queue_items[0].session_id if queue_items else None
+    prev_session_id: str | None = (
+        attention_queue[queue_index - 1].session_id
+        if (queue_index is not None and queue_index > 0)
+        else None
+    )
+
+    # Determine mode.
+    current_attention = attention_queue[queue_index] if queue_index is not None else None
+    mode = current_attention.action_type if current_attention else "findings"
+
+    # Normalise: "questions" maps to "findings" for template mode.
+    if mode == "questions":
+        mode = "findings"
+
+    # Wait label.
+    waiting_label = ""
+    if current_attention:
+        waiting_label = _format_wait_label(current_attention.wait_seconds)
+
+    # Steps and current step for ZingSession.
+    steps: list = []
+    current_step = None
+    notification = None
+    notification_body = ""
+
+    if isinstance(session, ZingSession):
+        steps = list(session.steps)
+        # Current step = last READY step.
+        current_step = next((s for s in reversed(steps) if s.state.value == "ready"), None)
+    elif isinstance(session, ClaudeCodeSession):
+        notification = session.pending_question
+        notification_body = notification.body if notification else ""
+
+    return {
+        "session": session,
+        "steps": steps,
+        "current_step": current_step,
+        "mode": mode,
+        "queue_position": queue_position,
+        "queue_total": max(queue_total, 1),
+        "queue_items": queue_items,
+        "next_session_id": next_session_id,
+        "prev_session_id": prev_session_id,
+        "waiting_label": waiting_label,
+        "notification": notification,
+        "notification_body": notification_body,
+    }
+
+
+@router.get("/command-center/drawer/{session_id}", response_class=HTMLResponse)
+async def get_drawer(session_id: str, request: Request) -> HTMLResponse:
+    """Return the drawer HTML fragment for a session.
+
+    The fragment includes backdrop + panel.  The JS injects it into
+    #review-drawer-container and sets display:block.
+    """
+    manager = request.app.state.session_manager
+    sessions = manager.list_sessions()
+    attention_queue = build_attention_queue(sessions, datetime.now(UTC))
+
+    ctx = build_drawer_context(session_id, manager, attention_queue)
+    if not ctx:
+        return HTMLResponse("<div>Session not found</div>", status_code=404)
+
+    session = ctx["session"]
+
+    if isinstance(session, ClaudeCodeSession):
+        # Attach mode — use the simpler attach template.
+        html = render("fragments/drawer_attach.html", **ctx)
+    else:
+        # Findings/questions mode.
+        html = render("fragments/review_drawer.html", **ctx)
+
+    return HTMLResponse(html)
+
+
+@router.get(
+    "/command-center/drawer/{session_id}/step/{step_id}",
+    response_class=HTMLResponse,
+)
+async def get_drawer_step(
+    session_id: str,
+    step_id: str,
+    request: Request,
+) -> HTMLResponse:
+    """Return a single step-history fragment for the drawer.
+
+    The JS can inject individual step sections when expanding collapsed history.
+    """
+    manager = request.app.state.session_manager
+    session = manager.get_session(session_id)
+    if session is None or not isinstance(session, ZingSession):
+        return HTMLResponse("<div>Session not found</div>", status_code=404)
+
+    step = next((s for s in session.steps if s.step_id == step_id), None)
+    if step is None:
+        return HTMLResponse("<div>Step not found</div>", status_code=404)
+
+    html = render("fragments/drawer_step_history.html", step=step, session=session)
+    return HTMLResponse(html)

--- a/src/zing_ai/server/routes_command_center.py
+++ b/src/zing_ai/server/routes_command_center.py
@@ -34,8 +34,13 @@ from zing_ai.launch import (
     rollback_worktree,
 )
 from zing_ai.server.attention import AttentionItem, build_attention_queue
-from zing_ai.server.command_center import aggregate, generate_standup, infer_repo_for_ticket
-from zing_ai.server.models import ClaudeCodeSession, ZingSession
+from zing_ai.server.command_center import (
+    aggregate,
+    build_session_phases,
+    generate_standup,
+    infer_repo_for_ticket,
+)
+from zing_ai.server.models import ClaudeCodeSession, Session, ZingSession
 from zing_ai.server.models_external import KanbanView
 from zing_ai.server.templates import render, render_markdown
 
@@ -186,18 +191,26 @@ def render_board_fragment(app: FastAPI) -> str:
     view = _build_view(app)
     cache = app.state.external_cache
     live_sessions: set[str] = getattr(app.state, "live_sessions", set())
+    sessions = app.state.session_manager.list_sessions()
+    session_phases = {}
+    for s in sessions:
+        if hasattr(s, "steps"):
+            session_phases[s.session_id] = build_session_phases(s)
     return render(
         "fragments/kanban_board.html",
         view=view,
         current_username=cache.github_username or "",
         live_sessions=live_sessions,
+        session_phases=session_phases,
     )
 
 
-def render_attention_bar_fragment(app: FastAPI) -> str:
+def render_attention_bar_fragment(app: FastAPI, sessions: list[Session] | None = None) -> str:
     """Render the attention bar fragment. Used by SSE board_changed events."""
-    sessions = app.state.session_manager.list_sessions()
-    attention_items = build_attention_queue(sessions, datetime.now(UTC))
+    resolved: list[Session] = (
+        sessions if sessions is not None else app.state.session_manager.list_sessions()
+    )
+    attention_items = build_attention_queue(resolved, datetime.now(UTC))
     return render(
         "fragments/attention_bar.html",
         attention_items=attention_items,
@@ -222,6 +235,10 @@ async def get_command_center(request: Request) -> HTMLResponse:
     sessions = request.app.state.session_manager.list_sessions()
     tray_data = _build_tray_data(view, sessions, live_sessions)
     attention_items = build_attention_queue(sessions, datetime.now(UTC))
+    session_phases = {}
+    for s in sessions:
+        if hasattr(s, "steps"):
+            session_phases[s.session_id] = build_session_phases(s)
     return HTMLResponse(
         render(
             "command_center.html",
@@ -234,6 +251,7 @@ async def get_command_center(request: Request) -> HTMLResponse:
             current_username=cache.github_username or "",
             live_sessions=live_sessions,
             attention_items=attention_items,
+            session_phases=session_phases,
             **tray_data,
         )
     )
@@ -257,13 +275,14 @@ async def command_center_events(request: Request):  # noqa: ANN201
                     continue
                 kind, _, _target = event.partition(":")
                 if kind == "board_changed":
+                    sessions = request.app.state.session_manager.list_sessions()
                     html = render_board_fragment(request.app)
                     yield SSE.patch_elements(
                         html,
                         selector="#kanban-board",
                         mode=ElementPatchMode.OUTER,
                     )
-                    attn_html = render_attention_bar_fragment(request.app)
+                    attn_html = render_attention_bar_fragment(request.app, sessions=sessions)
                     yield SSE.patch_elements(
                         attn_html,
                         selector="#attention-bar",
@@ -718,14 +737,17 @@ async def session_question(request: Request) -> JSONResponse:
     manager = request.app.state.session_manager
     # Direct lookup first.
     session = manager.get_session(session_id)
+    if session is not None and not isinstance(session, ClaudeCodeSession):
+        session = None  # Only accept ClaudeCodeSession for hook questions
     if session is None:
-        # Fallback: scan for a ClaudeCodeSession whose tmux_session matches.
+        # Fallback: scan for a ClaudeCodeSession whose terminal_session matches.
         for s in manager.list_sessions():
-            if isinstance(s, ClaudeCodeSession) and s.tmux_session == session_id:
+            if isinstance(s, ClaudeCodeSession) and s.terminal_session == session_id:
                 session = s
                 session_id = s.session_id
                 break
     if session is None:
+        logger.debug("session_question ignored: session_id=%s not found", session_id)
         return JSONResponse({"status": "ignored"})
     manager.add_notification(session_id, title="Input needed", body=question)
     return JSONResponse({"status": "ok"})
@@ -841,6 +863,7 @@ async def get_drawer(session_id: str, request: Request) -> HTMLResponse:
 
     ctx = build_drawer_context(session_id, manager, attention_queue)
     if not ctx:
+        logger.warning("Drawer requested for unknown session: %s", session_id)
         return HTMLResponse("<div>Session not found</div>", status_code=404)
 
     session = ctx["session"]
@@ -871,10 +894,12 @@ async def get_drawer_step(
     manager = request.app.state.session_manager
     session = manager.get_session(session_id)
     if session is None or not isinstance(session, ZingSession):
+        logger.warning("Drawer step not found: session=%s step=%s", session_id, step_id)
         return HTMLResponse("<div>Session not found</div>", status_code=404)
 
     step = next((s for s in session.steps if s.step_id == step_id), None)
     if step is None:
+        logger.warning("Drawer step not found: session=%s step=%s", session_id, step_id)
         return HTMLResponse("<div>Step not found</div>", status_code=404)
 
     html = render("fragments/drawer_step_history.html", step=step, session=session)

--- a/src/zing_ai/server/routes_command_center.py
+++ b/src/zing_ai/server/routes_command_center.py
@@ -33,6 +33,7 @@ from zing_ai.launch import (
     move_ticket_in_progress,
     rollback_worktree,
 )
+from zing_ai.server.attention import build_attention_queue
 from zing_ai.server.command_center import aggregate, generate_standup, infer_repo_for_ticket
 from zing_ai.server.models import ClaudeCodeSession
 from zing_ai.server.models_external import KanbanView
@@ -193,6 +194,16 @@ def render_board_fragment(app: FastAPI) -> str:
     )
 
 
+def render_attention_bar_fragment(app: FastAPI) -> str:
+    """Render the attention bar fragment. Used by SSE board_changed events."""
+    sessions = app.state.session_manager.list_sessions()
+    attention_items = build_attention_queue(sessions, datetime.now(UTC))
+    return render(
+        "fragments/attention_bar.html",
+        attention_items=attention_items,
+    )
+
+
 def _render_tray_fragment(app: FastAPI) -> str:
     """Render the management tray. Used by SSE board_changed events."""
     view = _build_view(app)
@@ -210,6 +221,7 @@ async def get_command_center(request: Request) -> HTMLResponse:
     live_sessions: set[str] = getattr(request.app.state, "live_sessions", set())
     sessions = request.app.state.session_manager.list_sessions()
     tray_data = _build_tray_data(view, sessions, live_sessions)
+    attention_items = build_attention_queue(sessions, datetime.now(UTC))
     return HTMLResponse(
         render(
             "command_center.html",
@@ -221,6 +233,7 @@ async def get_command_center(request: Request) -> HTMLResponse:
             body_class="command-center",
             current_username=cache.github_username or "",
             live_sessions=live_sessions,
+            attention_items=attention_items,
             **tray_data,
         )
     )
@@ -248,6 +261,12 @@ async def command_center_events(request: Request):  # noqa: ANN201
                     yield SSE.patch_elements(
                         html,
                         selector="#kanban-board",
+                        mode=ElementPatchMode.OUTER,
+                    )
+                    attn_html = render_attention_bar_fragment(request.app)
+                    yield SSE.patch_elements(
+                        attn_html,
+                        selector="#attention-bar",
                         mode=ElementPatchMode.OUTER,
                     )
                     tray_html = _render_tray_fragment(request.app)

--- a/src/zing_ai/server/routes_command_center.py
+++ b/src/zing_ai/server/routes_command_center.py
@@ -683,3 +683,30 @@ async def cleanup_worktree(request: Request) -> JSONResponse:
     manager.cleanup_session(session_id)
     _push_board_changed(request.app)
     return JSONResponse({"status": "cleaned_up"})
+
+
+@router.post("/command-center/session-question")
+async def session_question(request: Request) -> JSONResponse:
+    """Receive a question from a Claude Code hook and add it as a notification."""
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        return JSONResponse({"error": "Invalid JSON"}, status_code=400)
+    session_id = body.get("session_id")
+    question = body.get("question")
+    if not session_id or not question:
+        return JSONResponse({"status": "ignored"})
+    manager = request.app.state.session_manager
+    # Direct lookup first.
+    session = manager.get_session(session_id)
+    if session is None:
+        # Fallback: scan for a ClaudeCodeSession whose tmux_session matches.
+        for s in manager.list_sessions():
+            if isinstance(s, ClaudeCodeSession) and s.tmux_session == session_id:
+                session = s
+                session_id = s.session_id
+                break
+    if session is None:
+        return JSONResponse({"status": "ignored"})
+    manager.add_notification(session_id, title="Input needed", body=question)
+    return JSONResponse({"status": "ok"})

--- a/src/zing_ai/server/sessions.py
+++ b/src/zing_ai/server/sessions.py
@@ -844,8 +844,6 @@ class SessionManager:
     ) -> Notification:
         """Create a notification, append it to the session, persist, and notify."""
         session = self._get_session_or_raise(session_id)
-        if not isinstance(session, ZingSession):
-            raise KeyError(f"Session {session_id} is not a ZingSession")
         notification = Notification(title=title, body=body, url=url)
         session.notifications.append(notification)
         self._persist(session)

--- a/src/zing_ai/server/static/css/command_center.css
+++ b/src/zing_ai/server/static/css/command_center.css
@@ -1273,3 +1273,739 @@ a.strip-ci-dot[href] { cursor: pointer; }
 .card:hover .card-session-view {
     opacity: 1;
 }
+
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   REVIEW DRAWER
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+
+/* Board dims when drawer is open */
+body.drawer-open .board-wrapper {
+    opacity: 0.35;
+    filter: blur(1px);
+    pointer-events: none;
+    transition: opacity 0.2s, filter 0.2s;
+}
+
+/* FAB hides when drawer open */
+body.drawer-open .mgmt-fab {
+    opacity: 0;
+    pointer-events: none;
+}
+
+/* Backdrop */
+.drawer-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 27, 45, 0.3);
+    z-index: 150;
+}
+
+/* Drawer panel */
+.drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 500px;
+    max-width: 92vw;
+    background: var(--white);
+    z-index: 151;
+    box-shadow: -8px 0 32px rgba(15, 27, 45, 0.15);
+    transform: translateX(0);
+    transition: transform 0.25s ease;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Header */
+.dh {
+    padding: 0.75rem 1.15rem;
+    border-bottom: 1px solid var(--gray-200);
+    background: var(--gray-50);
+    flex-shrink: 0;
+}
+
+.dh-top {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.dh-close {
+    background: none;
+    border: none;
+    font-size: 1.15rem;
+    color: var(--gray-500);
+    cursor: pointer;
+    line-height: 1;
+    padding: 0;
+}
+
+.dh-close:hover {
+    color: var(--navy);
+}
+
+.dh-ticket {
+    font-size: 0.65rem;
+    font-weight: 700;
+    color: var(--orange);
+    text-transform: uppercase;
+}
+
+.dh-nav {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+
+.dh-nav-lbl {
+    font-size: 0.6rem;
+    color: var(--gray-500);
+}
+
+.dh-nav-btn {
+    width: 22px;
+    height: 22px;
+    border-radius: 4px;
+    border: 1px solid var(--gray-200);
+    background: var(--white);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 0.65rem;
+    color: var(--gray-700);
+    font-family: inherit;
+}
+
+.dh-nav-btn:hover:not(:disabled) {
+    background: var(--gray-50);
+    border-color: var(--gray-300);
+}
+
+.dh-nav-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.dh-title {
+    font-size: 0.95rem;
+    font-weight: 800;
+    color: var(--navy);
+    margin-top: 0.2rem;
+}
+
+.dh-meta {
+    display: flex;
+    gap: 0.6rem;
+    margin-top: 0.3rem;
+    font-size: 0.72rem;
+    color: var(--gray-500);
+    align-items: center;
+}
+
+.dh-badge {
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.badge-cyan {
+    background: rgba(62, 207, 224, 0.15);
+    color: var(--cyan-dim);
+}
+
+.badge-green {
+    background: rgba(22, 163, 74, 0.12);
+    color: #16a34a;
+}
+
+/* Timeline bar */
+.d-tl {
+    display: flex;
+    gap: 1px;
+    height: 16px;
+    border-radius: 4px;
+    overflow: hidden;
+    margin: 0.65rem 1.15rem 0;
+    flex-shrink: 0;
+}
+
+.ds {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.44rem;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.9);
+    overflow: hidden;
+}
+
+.ds-p { background: var(--orange); }
+.ds-a { background: var(--amber); }
+.ds-b { background: #7c3aed; }
+.ds-r { background: var(--cyan-dim); }
+.ds-w { background: #e2e8f0; color: var(--gray-500); }
+.ds-u { background: #16a34a; }
+
+.ds-wn {
+    background: repeating-linear-gradient(
+        -45deg,
+        #e2e8f0, #e2e8f0 3px,
+        #d1d5db 3px, #d1d5db 6px
+    );
+    animation: drawer-bp 1s linear infinite;
+    background-size: 12px 12px;
+    color: var(--gray-700);
+}
+
+@keyframes drawer-bp {
+    to { background-position: 12px 0; }
+}
+
+.d-tl-info {
+    display: flex;
+    gap: 0.4rem;
+    padding: 0.2rem 1.15rem;
+    font-size: 0.52rem;
+    color: var(--gray-500);
+    flex-shrink: 0;
+}
+
+/* Scrollable body */
+.d-body {
+    flex: 1;
+    overflow-y: auto;
+}
+
+/* Step sections */
+.step-section {
+    border-bottom: 1px solid var(--gray-200);
+}
+
+.step-section:last-child {
+    border-bottom: none;
+}
+
+.step-hdr {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.55rem 1.15rem;
+    cursor: pointer;
+    user-select: none;
+    transition: background 0.1s;
+}
+
+.step-hdr:hover {
+    background: var(--gray-50);
+}
+
+.step-chv {
+    font-size: 0.5rem;
+    color: var(--gray-400);
+    transition: transform 0.15s;
+    flex-shrink: 0;
+}
+
+.step-section.open .step-chv {
+    transform: rotate(90deg);
+}
+
+.step-ico {
+    font-size: 0.85rem;
+}
+
+.step-name {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--navy);
+}
+
+.step-badge {
+    padding: 0.08rem 0.4rem;
+    border-radius: 999px;
+    font-size: 0.52rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.sbg-completed { background: rgba(22, 163, 74, 0.12); color: #16a34a; }
+.sbg-ready { background: rgba(62, 207, 224, 0.15); color: var(--cyan-dim); }
+.sbg-started { background: rgba(245, 124, 32, 0.12); color: var(--orange); }
+
+.step-time {
+    margin-left: auto;
+    font-size: 0.6rem;
+    color: var(--gray-500);
+}
+
+.step-content {
+    display: none;
+    padding: 0 1.15rem 0.75rem;
+}
+
+.step-section.open .step-content {
+    display: block;
+}
+
+/* Agent rows */
+.agent-row {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.25rem 0;
+    font-size: 0.75rem;
+}
+
+.ag-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: #16a34a;
+}
+
+.ag-name {
+    font-weight: 600;
+    color: var(--navy);
+}
+
+.ag-desc {
+    color: var(--gray-500);
+}
+
+.ag-time {
+    margin-left: auto;
+    font-size: 0.6rem;
+    color: var(--gray-500);
+}
+
+/* Per-finding response rows (history) */
+.hist-findings {
+    margin-top: 0.5rem;
+}
+
+.hist-finding {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.35rem 0;
+    border-bottom: 1px solid var(--gray-100);
+    font-size: 0.72rem;
+}
+
+.hist-finding:last-child {
+    border-bottom: none;
+}
+
+.hf-action {
+    padding: 0.08rem 0.35rem;
+    border-radius: 4px;
+    font-size: 0.5rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    flex-shrink: 0;
+    margin-top: 0.06rem;
+}
+
+.hfa-accept, .hfa-accepted {
+    background: #dcfce7;
+    color: #15803d;
+}
+
+.hfa-drop, .hfa-dropped {
+    background: var(--gray-100);
+    color: var(--gray-500);
+    text-decoration: line-through;
+}
+
+.hfa-discuss, .hfa-discussed {
+    background: #ecfeff;
+    color: var(--cyan-dim);
+}
+
+.hfa-answer, .hfa-answered {
+    background: #fff7ed;
+    color: #c2410c;
+}
+
+.hfa-downgrade, .hfa-downgraded {
+    background: #fef9c3;
+    color: #854d0e;
+}
+
+.hf-body {
+    flex: 1;
+    min-width: 0;
+}
+
+.hf-title {
+    font-weight: 600;
+    color: var(--navy);
+}
+
+.hf-dropped {
+    color: var(--gray-500);
+    text-decoration: line-through;
+}
+
+.hf-response {
+    font-size: 0.68rem;
+    color: var(--gray-700);
+    margin-top: 0.15rem;
+    padding-left: 0.5rem;
+    border-left: 2px solid var(--gray-200);
+    font-style: italic;
+}
+
+/* Current findings area */
+.findings-area {
+    padding: 0 1.15rem 0.75rem;
+}
+
+.d-ft {
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--gray-500);
+    margin: 0.5rem 0 0.45rem;
+}
+
+.df {
+    background: var(--gray-50);
+    border: 1px solid var(--gray-200);
+    border-radius: 8px;
+    padding: 0.6rem 0.8rem;
+    margin-bottom: 0.45rem;
+}
+
+.df-h {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-bottom: 0.25rem;
+}
+
+.df-s {
+    padding: 0.06rem 0.35rem;
+    border-radius: 999px;
+    font-size: 0.5rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.df-hi { background: #fee2e2; color: #991b1b; }
+.df-me { background: #fef3c7; color: #92400e; }
+.df-in { background: #e0e7ff; color: #3730a3; }
+
+.df-t {
+    font-weight: 600;
+    color: var(--navy);
+    font-size: 0.82rem;
+}
+
+.df-b {
+    font-size: 0.78rem;
+    color: var(--gray-700);
+    line-height: 1.5;
+}
+
+.df-b code {
+    background: var(--gray-100);
+    padding: 0.06rem 0.25rem;
+    border-radius: 3px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.72rem;
+}
+
+.df-l {
+    font-size: 0.62rem;
+    color: var(--gray-500);
+    font-family: monospace;
+    margin-top: 0.2rem;
+}
+
+.df-tr {
+    display: flex;
+    gap: 0.25rem;
+    margin-top: 0.4rem;
+    flex-wrap: wrap;
+    align-items: flex-start;
+}
+
+.df-tb {
+    padding: 0.22rem 0.5rem;
+    border-radius: 6px;
+    border: 2px solid var(--gray-200);
+    background: var(--white);
+    font-size: 0.68rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.12s;
+    font-family: inherit;
+}
+
+.df-tb:hover {
+    border-color: var(--gray-300);
+}
+
+.df-tb.sa { border-color: #16a34a; background: #f0fdf4; color: #16a34a; }
+.df-tb.sd { border-color: var(--gray-300); background: var(--gray-50); color: var(--gray-500); }
+.df-tb.sdisc { border-color: var(--cyan); background: #ecfeff; color: var(--cyan-dim); }
+
+.df-answer {
+    width: 100%;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--gray-200);
+    border-radius: 6px;
+    font-size: 0.78rem;
+    font-family: inherit;
+    resize: vertical;
+    color: var(--navy);
+    background: var(--white);
+}
+
+.df-answer:focus {
+    outline: none;
+    border-color: var(--orange);
+    box-shadow: 0 0 0 2px rgba(245, 124, 32, 0.15);
+}
+
+/* Attach hero */
+.attach-hero {
+    background: linear-gradient(135deg, #eff6ff, #dbeafe);
+    border: 2px solid #93c5fd;
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+    text-align: center;
+    margin: 0.75rem 1.15rem;
+}
+
+.attach-hero-icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: #3b82f6;
+    color: var(--white);
+    margin: 0 auto 0.6rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.1rem;
+    font-weight: 800;
+    animation: drawer-atp 2s ease-out infinite;
+}
+
+@keyframes drawer-atp {
+    0% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.4); }
+    70% { box-shadow: 0 0 0 10px rgba(59, 130, 246, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0); }
+}
+
+.attach-hero h3 {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--navy);
+    margin-bottom: 0.3rem;
+}
+
+.attach-hero p {
+    font-size: 0.78rem;
+    color: var(--gray-700);
+    line-height: 1.4;
+    margin-bottom: 0.6rem;
+}
+
+.attach-hero-btn {
+    padding: 0.5rem 1.25rem;
+    border-radius: 8px;
+    background: #3b82f6;
+    color: var(--white);
+    font-weight: 700;
+    font-size: 0.85rem;
+    border: none;
+    cursor: pointer;
+    box-shadow: 0 3px 10px rgba(59, 130, 246, 0.3);
+    font-family: inherit;
+}
+
+.attach-hero-btn:hover {
+    background: #2563eb;
+}
+
+.attach-ctx {
+    margin: 0.5rem 1.15rem;
+}
+
+.attach-ctx-title {
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--gray-500);
+    margin-bottom: 0.35rem;
+}
+
+.attach-msg {
+    background: var(--gray-50);
+    border: 1px solid var(--gray-200);
+    border-radius: 8px;
+    padding: 0.55rem 0.75rem;
+    font-size: 0.75rem;
+    color: var(--gray-700);
+    line-height: 1.5;
+}
+
+/* Footer */
+.d-footer {
+    padding: 0.65rem 1.15rem;
+    border-top: 1px solid var(--gray-200);
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    background: var(--gray-50);
+    flex-shrink: 0;
+}
+
+.d-fprog {
+    flex: 1;
+    font-size: 0.75rem;
+    color: var(--gray-500);
+}
+
+.d-fprog strong {
+    color: var(--navy);
+}
+
+.d-fskip {
+    padding: 0.4rem 0.7rem;
+    border-radius: 6px;
+    border: 1px solid var(--gray-200);
+    background: var(--white);
+    color: var(--gray-500);
+    font-size: 0.75rem;
+    font-weight: 600;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.d-fskip:hover {
+    background: var(--gray-50);
+    border-color: var(--gray-300);
+}
+
+.d-fsub {
+    padding: 0.4rem 1.1rem;
+    border-radius: 6px;
+    background: var(--orange);
+    color: var(--white);
+    font-weight: 700;
+    font-size: 0.82rem;
+    border: none;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(245, 124, 32, 0.25);
+    font-family: inherit;
+    transition: all 0.15s;
+}
+
+.d-fsub:hover {
+    background: var(--orange-hover);
+    transform: translateY(-1px);
+}
+
+.d-fsub:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+}
+
+/* Up next queue */
+.d-queue {
+    border-top: 2px solid var(--gray-200);
+    padding: 0.4rem 1.15rem 0.5rem;
+    background: var(--white);
+    flex-shrink: 0;
+}
+
+.d-qt {
+    font-size: 0.55rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--gray-500);
+    margin-bottom: 0.25rem;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+
+.d-qc {
+    background: var(--orange);
+    color: var(--white);
+    padding: 0.04rem 0.3rem;
+    border-radius: 999px;
+    font-size: 0.48rem;
+}
+
+.d-qi {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.22rem 0.25rem;
+    font-size: 0.68rem;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+.d-qi:hover {
+    background: var(--gray-50);
+}
+
+.d-qi-ico {
+    width: 16px;
+    height: 16px;
+    border-radius: 4px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.45rem;
+    font-weight: 800;
+}
+
+.qi-findings { background: rgba(62, 207, 224, 0.15); color: var(--cyan-dim); }
+.qi-attach { background: rgba(59, 130, 246, 0.15); color: #3b82f6; }
+.qi-question { background: rgba(245, 124, 32, 0.15); color: var(--orange); }
+
+.d-qid {
+    font-weight: 700;
+    color: var(--orange);
+    font-size: 0.55rem;
+    text-transform: uppercase;
+}
+
+.d-qtl {
+    color: var(--gray-700);
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.d-qa {
+    font-size: 0.52rem;
+    font-weight: 600;
+    padding: 0.06rem 0.3rem;
+    border-radius: 4px;
+    flex-shrink: 0;
+}
+
+.qa-review { background: rgba(62, 207, 224, 0.12); color: var(--cyan-dim); }
+.qa-attach { background: rgba(59, 130, 246, 0.12); color: #3b82f6; }
+.qa-answer { background: rgba(245, 124, 32, 0.12); color: var(--orange); }

--- a/src/zing_ai/server/static/css/command_center.css
+++ b/src/zing_ai/server/static/css/command_center.css
@@ -951,3 +951,208 @@ a.strip-ci-dot[href] { cursor: pointer; }
 .mgmt-btn-danger:hover { background: rgba(232,68,48,0.05); }
 .mgmt-row-empty { font-size: 0.75rem; color: var(--gray-400); font-style: italic; padding: 0.5rem 0; }
 .mgmt-orphan-tag { font-size: 0.55rem; font-weight: 700; text-transform: uppercase; background: #fff3e0; color: #e65100; padding: 0.1rem 0.3rem; border-radius: 999px; margin-left: 0.25rem; }
+
+/* ──────────────────────────────────────────────
+   ATTENTION BAR
+────────────────────────────────────────────── */
+
+#attention-bar {
+    /* Wrapper element for SSE OUTER-mode patches. No visual styling — the
+       inner .attn-bar <details> element carries all the appearance. */
+}
+
+.attn-bar {
+    background: linear-gradient(135deg, var(--white), #fffaf5);
+    border: 1px solid #ffd9c2;
+    border-radius: 8px;
+    margin-bottom: 1rem;
+    overflow: hidden;
+    box-shadow: 0 1px 8px rgba(245, 124, 32, 0.06);
+}
+
+.attn-hdr {
+    padding: 0.4rem 0.75rem;
+    background: linear-gradient(135deg, #fff5ee, #ffe8d4);
+    border-bottom: 1px solid #ffd9c2;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.68rem;
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+}
+
+/* Remove default <summary> marker */
+.attn-hdr::-webkit-details-marker { display: none; }
+.attn-hdr::marker { display: none; }
+
+/* When collapsed, remove bottom border from header */
+.attn-bar:not([open]) .attn-hdr {
+    border-bottom: none;
+}
+
+.attn-ico {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--white);
+    border: 2px solid var(--orange);
+    color: var(--orange);
+    font-size: 0.55rem;
+    font-weight: 800;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.attn-ttl {
+    font-weight: 700;
+    color: var(--navy);
+}
+
+.attn-cnt {
+    background: var(--orange);
+    color: var(--white);
+    padding: 0.06rem 0.35rem;
+    border-radius: 999px;
+    font-size: 0.5rem;
+    font-weight: 700;
+}
+
+.attn-chv {
+    margin-left: auto;
+    font-size: 0.6rem;
+    color: var(--gray-400);
+    transition: transform 0.15s;
+}
+
+.attn-bar:not([open]) .attn-chv {
+    transform: rotate(-90deg);
+}
+
+.attn-items {
+    /* Container for all attention items — visible when <details> is open */
+}
+
+.attn-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.75rem;
+    border-bottom: 1px solid rgba(255, 217, 194, 0.4);
+    transition: background 0.1s;
+}
+
+.attn-item:last-child {
+    border-bottom: none;
+}
+
+.attn-item:hover {
+    background: rgba(245, 124, 32, 0.04);
+}
+
+.attn-type-ico {
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.6rem;
+    font-weight: 800;
+}
+
+.type-findings {
+    background: rgba(62, 207, 224, 0.15);
+    color: var(--cyan-dim);
+}
+
+.type-attach {
+    background: rgba(59, 130, 246, 0.15);
+    color: var(--blue);
+}
+
+.type-question {
+    background: rgba(245, 124, 32, 0.15);
+    color: var(--orange);
+}
+
+.attn-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.attn-top-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.35rem;
+}
+
+.attn-tid {
+    font-size: 0.55rem;
+    font-weight: 700;
+    color: var(--orange);
+    text-transform: uppercase;
+    flex-shrink: 0;
+}
+
+.attn-lbl {
+    font-size: 0.68rem;
+    font-weight: 600;
+    color: var(--navy);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.attn-desc {
+    font-size: 0.58rem;
+    color: var(--gray-500);
+    margin-top: 0.1rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.attn-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.58rem;
+    color: var(--gray-500);
+    flex-shrink: 0;
+}
+
+.attn-step {
+    padding: 0.06rem 0.28rem;
+    border-radius: 4px;
+    font-weight: 600;
+    font-size: 0.5rem;
+}
+
+/* Step badge color variants */
+.stp-ba { background: rgba(62, 207, 224, 0.15); color: var(--cyan-dim); }
+.stp-pl { background: rgba(245, 124, 32, 0.15); color: var(--orange); }
+.stp-bu { background: rgba(124, 58, 237, 0.15); color: #7c3aed; }
+.stp-cr { background: rgba(232, 68, 48, 0.15); color: var(--red-orange); }
+
+.attn-btn {
+    padding: 0.18rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.55rem;
+    font-weight: 700;
+    border: none;
+    cursor: pointer;
+    flex-shrink: 0;
+    font-family: inherit;
+    transition: opacity 0.15s;
+}
+
+.attn-btn:hover { opacity: 0.85; }
+
+.btn-rev { background: var(--orange); color: var(--white); }
+.btn-ans { background: var(--cyan); color: var(--white); }
+.btn-att { background: var(--blue); color: var(--white); }

--- a/src/zing_ai/server/static/css/command_center.css
+++ b/src/zing_ai/server/static/css/command_center.css
@@ -1156,3 +1156,120 @@ a.strip-ci-dot[href] { cursor: pointer; }
 .btn-rev { background: var(--orange); color: var(--white); }
 .btn-ans { background: var(--cyan); color: var(--white); }
 .btn-att { background: var(--blue); color: var(--white); }
+
+/* ──────────────────────────────────────────────
+   CARD ATTACH STRIP (blue — Claude Code pending question)
+────────────────────────────────────────────── */
+
+.card-attach-strip {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.6rem;
+    background: linear-gradient(135deg, #eff6ff, #dbeafe);
+    border-top: 1px solid rgba(59, 130, 246, 0.3);
+    font-size: 0.48rem;
+}
+
+/* Pulsing blue dot */
+.card-attach-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--blue);
+    flex-shrink: 0;
+    animation: card-attach-pulse 2s ease-out infinite;
+}
+
+@keyframes card-attach-pulse {
+    0%   { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.4); }
+    70%  { box-shadow: 0 0 0 3px rgba(59, 130, 246, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0); }
+}
+
+.card-attach-text {
+    font-weight: 600;
+    color: var(--blue-dark);
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.card-attach-btn {
+    padding: 0.12rem 0.35rem;
+    border-radius: 3px;
+    background: var(--blue);
+    color: var(--white);
+    border: none;
+    font-size: 0.42rem;
+    font-weight: 700;
+    cursor: pointer;
+    font-family: inherit;
+    flex-shrink: 0;
+    transition: opacity 0.15s;
+}
+.card-attach-btn:hover { opacity: 0.85; }
+
+/* ──────────────────────────────────────────────
+   CARD SESSION STRIP (history — subtle, with mini timeline)
+────────────────────────────────────────────── */
+
+.card-session-strip {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.2rem 0.6rem;
+    border-top: 1px solid var(--gray-100);
+    cursor: pointer;
+    transition: background 0.1s;
+    font-size: 0.48rem;
+}
+
+.card-session-strip:hover {
+    background: var(--gray-50);
+}
+
+/* Mini 6px phase bar */
+.card-session-phases {
+    display: flex;
+    gap: 1px;
+    height: 6px;
+    flex: 1;
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+/* Phase segment base */
+.css-seg {
+    height: 100%;
+}
+
+/* Phase segment color variants — mirror prototype .css-p/.css-a/.css-b/.css-r/.css-w/.css-u */
+.css-p { background: var(--orange); }
+.css-a { background: var(--amber); }
+.css-b { background: #7c3aed; }
+.css-r { background: var(--cyan-dim); }
+.css-w { background: #e2e8f0; }
+.css-u { background: #16a34a; }
+
+.card-session-label {
+    font-size: 0.42rem;
+    color: var(--gray-500);
+    font-weight: 600;
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+
+.card-session-view {
+    font-size: 0.42rem;
+    color: var(--orange);
+    font-weight: 700;
+    flex-shrink: 0;
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+
+.card:hover .card-session-view {
+    opacity: 1;
+}

--- a/src/zing_ai/server/static/css/command_center.css
+++ b/src/zing_ai/server/static/css/command_center.css
@@ -397,7 +397,7 @@ a.strip-ci-dot[href] { cursor: pointer; }
     border-radius: 50%;
     flex-shrink: 0;
 }
-.strip-session-alive { background: #3b82f6; animation: cc-pulse 2s infinite; }
+.strip-session-alive { background: var(--blue); animation: cc-pulse 2s infinite; }
 .strip-session-dead  { background: var(--gray-300); }
 
 .strip-session-label {
@@ -1166,7 +1166,7 @@ a.strip-ci-dot[href] { cursor: pointer; }
     align-items: center;
     gap: 0.35rem;
     padding: 0.25rem 0.6rem;
-    background: linear-gradient(135deg, #eff6ff, #dbeafe);
+    background: linear-gradient(135deg, var(--blue-subtle), #dbeafe);
     border-top: 1px solid rgba(59, 130, 246, 0.3);
     font-size: 0.48rem;
 }
@@ -1779,7 +1779,7 @@ body.drawer-open .mgmt-fab {
 
 /* Attach hero */
 .attach-hero {
-    background: linear-gradient(135deg, #eff6ff, #dbeafe);
+    background: linear-gradient(135deg, var(--blue-subtle), #dbeafe);
     border: 2px solid #93c5fd;
     border-radius: 10px;
     padding: 1rem 1.25rem;
@@ -1791,7 +1791,7 @@ body.drawer-open .mgmt-fab {
     width: 44px;
     height: 44px;
     border-radius: 50%;
-    background: #3b82f6;
+    background: var(--blue);
     color: var(--white);
     margin: 0 auto 0.6rem;
     display: flex;
@@ -1825,7 +1825,7 @@ body.drawer-open .mgmt-fab {
 .attach-hero-btn {
     padding: 0.5rem 1.25rem;
     border-radius: 8px;
-    background: #3b82f6;
+    background: var(--blue);
     color: var(--white);
     font-weight: 700;
     font-size: 0.85rem;
@@ -1836,7 +1836,7 @@ body.drawer-open .mgmt-fab {
 }
 
 .attach-hero-btn:hover {
-    background: #2563eb;
+    background: var(--blue-dark);
 }
 
 .attach-ctx {
@@ -1980,7 +1980,7 @@ body.drawer-open .mgmt-fab {
 }
 
 .qi-findings { background: rgba(62, 207, 224, 0.15); color: var(--cyan-dim); }
-.qi-attach { background: rgba(59, 130, 246, 0.15); color: #3b82f6; }
+.qi-attach { background: rgba(59, 130, 246, 0.15); color: var(--blue); }
 .qi-question { background: rgba(245, 124, 32, 0.15); color: var(--orange); }
 
 .d-qid {
@@ -2007,5 +2007,5 @@ body.drawer-open .mgmt-fab {
 }
 
 .qa-review { background: rgba(62, 207, 224, 0.12); color: var(--cyan-dim); }
-.qa-attach { background: rgba(59, 130, 246, 0.12); color: #3b82f6; }
+.qa-attach { background: rgba(59, 130, 246, 0.12); color: var(--blue); }
 .qa-answer { background: rgba(245, 124, 32, 0.12); color: var(--orange); }

--- a/src/zing_ai/server/static/css/tokens.css
+++ b/src/zing_ai/server/static/css/tokens.css
@@ -21,6 +21,9 @@
     --amber-subtle: #fffbeb;
     --amber-glow: rgba(245, 166, 35, 0.18);
     --cyan-subtle: #e0f7fa;
+    --blue: #3b82f6;
+    --blue-dark: #2563eb;
+    --blue-subtle: #eff6ff;
     --gray-50: #faf9f7;
     --gray-100: #f3f1ee;
     --gray-200: #e8e5e1;

--- a/src/zing_ai/server/templates/command_center.html
+++ b/src/zing_ai/server/templates/command_center.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="cc-page"
-     data-signals='{{ {"lastPolledLabel": last_polled_label or "", "lastError": last_error or "", "launchingCards": []} | tojson }}'
+     data-signals='{{ {"lastPolledLabel": last_polled_label or "", "lastError": last_error or "", "launchingCards": [], "attnBarOpen": true} | tojson }}'
      data-init="@get('/command-center/events')">
     {# Render inline display:none when there is no server-side error, so the
        empty red banner doesn't flash before Datastar initialises. The
@@ -538,6 +538,8 @@
             btn.innerHTML = '&#10007; Failed';
             setTimeout(function() { btn.innerHTML = 'Resume'; btn.disabled = false; }, 3000);
         });
+    });
+
     // ── Review Drawer ────────────────────────────────────────────────────────
 
     // Current drawer state.

--- a/src/zing_ai/server/templates/command_center.html
+++ b/src/zing_ai/server/templates/command_center.html
@@ -35,6 +35,8 @@
         })(this)">&#x21BB; Refresh</button>
     </div>
 
+{% include 'fragments/attention_bar.html' %}
+
 {% include "fragments/kanban_board.html" %}
 
     <div id="mgmt-tray">

--- a/src/zing_ai/server/templates/command_center.html
+++ b/src/zing_ai/server/templates/command_center.html
@@ -43,6 +43,9 @@
     {% include "fragments/management_tray.html" %}
     </div>
 
+    {# ── Review drawer container ── #}
+    <div id="review-drawer-container" style="display:none"></div>
+
     {# ── Terminal modal (Zellij iframe) ── #}
     <div id="terminal-modal" class="terminal-modal" style="display:none;">
       <div class="terminal-modal-bar">
@@ -535,6 +538,204 @@
             btn.innerHTML = '&#10007; Failed';
             setTimeout(function() { btn.innerHTML = 'Resume'; btn.disabled = false; }, 3000);
         });
+    // ── Review Drawer ────────────────────────────────────────────────────────
+
+    // Current drawer state.
+    var _drawerSessionId = null;
+    var _drawerMode = null;
+
+    window.openReviewDrawer = function(sessionId, mode) {
+        if (!sessionId) return;
+        _drawerSessionId = sessionId;
+        _drawerMode = mode || 'findings';
+        var container = document.getElementById('review-drawer-container');
+        container.innerHTML = '<div style="position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);z-index:202;font-size:0.75rem;color:var(--gray-500)">Loading\u2026</div>';
+        container.style.display = 'block';
+        document.body.classList.add('drawer-open');
+
+        fetch('/command-center/drawer/' + encodeURIComponent(sessionId))
+            .then(function(r) { return r.text(); })
+            .then(function(html) {
+                container.innerHTML = html;
+                // Update triage counter after inject.
+                _updateTriageCount();
+            })
+            .catch(function(err) {
+                container.innerHTML = '<div style="position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);z-index:202;color:red">Failed to load drawer: ' + err.message + '</div>';
+            });
+    };
+
+    window.closeReviewDrawer = function() {
+        var container = document.getElementById('review-drawer-container');
+        container.style.display = 'none';
+        container.innerHTML = '';
+        document.body.classList.remove('drawer-open');
+        _drawerSessionId = null;
+        _drawerMode = null;
+    };
+
+    // Nav arrows: prev / next in queue.
+    window.drawerNavPrev = function() {
+        var queue = document.querySelector('.d-queue[data-prev-session-id]');
+        var prevId = queue ? queue.getAttribute('data-prev-session-id') : null;
+        if (prevId) window.openReviewDrawer(prevId);
+    };
+
+    window.drawerNavNext = function() {
+        var queue = document.querySelector('.d-queue[data-next-session-id]');
+        var nextId = queue ? queue.getAttribute('data-next-session-id') : null;
+        if (nextId) window.openReviewDrawer(nextId);
+        else window.closeReviewDrawer();
+    };
+
+    // Skip: advance without submitting.
+    window.skipToNext = function() {
+        var btn = document.getElementById('drawer-submit-btn');
+        var nextId = btn ? btn.getAttribute('data-next-session-id') : null;
+        // Fall back to d-queue data attribute.
+        if (!nextId) {
+            var queue = document.querySelector('.d-queue[data-next-session-id]');
+            nextId = queue ? queue.getAttribute('data-next-session-id') : null;
+        }
+        if (nextId) {
+            window.openReviewDrawer(nextId);
+        } else {
+            // Queue empty.
+            _showAllCaughtUp();
+        }
+    };
+
+    // Submit + load next.
+    window.submitAndNext = function() {
+        var btn = document.getElementById('drawer-submit-btn');
+        if (!btn) return;
+        var sessionId = btn.getAttribute('data-session-id');
+        var stepId = btn.getAttribute('data-step-id');
+        var nextId = btn.getAttribute('data-next-session-id');
+
+        if (!sessionId || !stepId) return;
+
+        // Gather triage responses from the current drawer DOM.
+        var responses = {};
+        // Triage button selections.
+        document.querySelectorAll('.df-tb.sa, .df-tb.sd, .df-tb.sdisc').forEach(function(tbtn) {
+            var findingId = tbtn.getAttribute('data-finding-id');
+            var action = tbtn.getAttribute('data-action');
+            if (findingId && action) responses[findingId] = action;
+        });
+        // Text answers.
+        document.querySelectorAll('.df-answer').forEach(function(ta) {
+            var findingId = ta.getAttribute('data-finding-id');
+            if (findingId && ta.value.trim()) responses[findingId] = ta.value.trim();
+        });
+
+        btn.disabled = true;
+        btn.textContent = 'Submitting\u2026';
+
+        fetch('/' + encodeURIComponent(sessionId) + '/submit', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({step_id: stepId, responses: responses})
+        }).then(function(r) {
+            if (r.ok) {
+                if (nextId) {
+                    window.openReviewDrawer(nextId);
+                } else {
+                    _showAllCaughtUp();
+                }
+            } else {
+                btn.disabled = false;
+                btn.textContent = 'Submit \u0026 Next';
+                showToast('Submit failed (HTTP ' + r.status + ')', 'error');
+            }
+        }).catch(function(err) {
+            btn.disabled = false;
+            btn.textContent = 'Submit \u0026 Next';
+            showToast('Submit failed: ' + err.message, 'error');
+        });
+    };
+
+    // Triage button toggle.
+    window.drawerTriage = function(tbtn) {
+        var row = tbtn.closest('.df-tr');
+        if (!row) return;
+        var wasActive = tbtn.classList.contains('sa') || tbtn.classList.contains('sd') || tbtn.classList.contains('sdisc');
+        // Clear all in row.
+        row.querySelectorAll('.df-tb').forEach(function(b) {
+            b.className = 'df-tb';
+            b.setAttribute('data-action', b.getAttribute('data-action'));
+        });
+        if (!wasActive) {
+            var action = tbtn.getAttribute('data-action');
+            if (action === 'accept') tbtn.classList.add('sa');
+            else if (action === 'drop') tbtn.classList.add('sd');
+            else if (action === 'discuss') tbtn.classList.add('sdisc');
+        }
+        _updateTriageCount();
+    };
+
+    function _updateTriageCount() {
+        var counter = document.getElementById('drawer-triage-count');
+        if (!counter) return;
+        var total = document.querySelectorAll('.df-tr').length + document.querySelectorAll('.df-answer').length;
+        var done = document.querySelectorAll('.df-tb.sa, .df-tb.sd, .df-tb.sdisc').length;
+        document.querySelectorAll('.df-answer').forEach(function(ta) {
+            if (ta.value.trim()) done++;
+        });
+        counter.textContent = done;
+    }
+
+    function _showAllCaughtUp() {
+        var container = document.getElementById('review-drawer-container');
+        // Briefly show "All caught up" then close.
+        if (container) {
+            container.innerHTML = '<div style="position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);z-index:202;background:#fff;border-radius:12px;padding:1.5rem 2rem;text-align:center;box-shadow:0 8px 32px rgba(0,0,0,0.15)"><div style="font-size:1.5rem">&#10003;</div><div style="font-size:1rem;font-weight:700;color:var(--navy);margin-top:0.5rem">All caught up</div></div>';
+        }
+        setTimeout(function() { window.closeReviewDrawer(); }, 2000);
+    }
+
+    // Open terminal from drawer (pass-through to existing openTerminal helper, mode=browser).
+    window.openTerminalFromDrawer = function(sessionId) {
+        if (!sessionId) return;
+        fetch('/command-center/attach-session', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({terminal_session: sessionId, mode: 'browser'})
+        }).then(function(r) { return r.json().then(function(data) {
+            if (data.url) {
+                window.openTerminal(data.url, sessionId);
+                window.closeReviewDrawer();
+            } else {
+                showToast(data.error || 'Attach failed', 'error');
+            }
+        }); }).catch(function(err) {
+            showToast('Attach failed: ' + err.message, 'error');
+        });
+    };
+
+    // Delegated click handler for data-open-drawer elements.
+    document.addEventListener('click', function(e) {
+        var el = e.target.closest('[data-open-drawer]');
+        if (!el) return;
+        // Don't intercept if it's a button inside an element that also has data-open-drawer
+        // (the button should take priority over the parent).
+        var sessionId = el.getAttribute('data-open-drawer');
+        var mode = el.getAttribute('data-open-drawer-mode') || el.getAttribute('data-drawer-mode') || 'findings';
+        if (sessionId) {
+            e.stopPropagation();
+            window.openReviewDrawer(sessionId, mode);
+        }
+    });
+
+    // ESC key closes drawer (in addition to management tray).
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') {
+            var container = document.getElementById('review-drawer-container');
+            if (container && container.style.display !== 'none' && container.innerHTML) {
+                window.closeReviewDrawer();
+                return;
+            }
+        }
     });
     </script>
 

--- a/src/zing_ai/server/templates/fragments/attention_bar.html
+++ b/src/zing_ai/server/templates/fragments/attention_bar.html
@@ -46,7 +46,10 @@
         {% set wait_lbl = (item.wait_seconds // 3600) ~ "h" %}
       {% endif %}
 
-      <div class="attn-item">
+      <div class="attn-item"
+           data-open-drawer="{{ item.session_id }}"
+           data-open-drawer-mode="{{ item.action_type }}"
+           style="cursor:pointer">
         <div class="attn-type-ico {{ type_cls }}">{{ icon }}</div>
         <div class="attn-info">
           <div class="attn-top-row">
@@ -70,7 +73,9 @@
           {% endif %}
           <span>{{ wait_lbl }}</span>
         </div>
-        <button class="attn-btn {{ btn_cls }}">{{ btn_lbl }}</button>
+        <button class="attn-btn {{ btn_cls }}"
+                data-open-drawer="{{ item.session_id }}"
+                data-open-drawer-mode="{{ item.action_type }}">{{ btn_lbl }}</button>
       </div>
     {% endfor %}
   </div>

--- a/src/zing_ai/server/templates/fragments/attention_bar.html
+++ b/src/zing_ai/server/templates/fragments/attention_bar.html
@@ -1,0 +1,79 @@
+{#
+  attention_bar.html — renders the attention bar above the kanban board.
+
+  Expected context variables:
+    attention_items  — list[AttentionItem] from build_attention_queue()
+
+  Hidden entirely when attention_items is empty.
+  Collapsible via <details>/<summary> — preserves open/closed state across SSE patches.
+
+  The outer <div id="attention-bar"> is included here so that OUTER-mode SSE
+  patches can replace this element in-place (same pattern as kanban_board.html).
+#}
+<div id="attention-bar">
+{% if attention_items %}
+<details class="attn-bar" open>
+  <summary class="attn-hdr">
+    <div class="attn-ico">!</div>
+    <span class="attn-ttl">Needs your attention</span>
+    <span class="attn-cnt">{{ attention_items | length }}</span>
+    <span class="attn-chv">&#9660;</span>
+  </summary>
+  <div class="attn-items">
+    {% for item in attention_items %}
+      {% if item.action_type == "findings" %}
+        {% set type_cls = "type-findings" %}
+        {% set icon = "&#9998;" %}
+        {% set btn_cls = "btn-rev" %}
+        {% set btn_lbl = "Review" %}
+      {% elif item.action_type == "attach" %}
+        {% set type_cls = "type-attach" %}
+        {% set icon = "&#9654;" %}
+        {% set btn_cls = "btn-att" %}
+        {% set btn_lbl = "Attach" %}
+      {% else %}
+        {% set type_cls = "type-question" %}
+        {% set icon = "?" %}
+        {% set btn_cls = "btn-ans" %}
+        {% set btn_lbl = "Answer" %}
+      {% endif %}
+
+      {% if item.wait_seconds < 60 %}
+        {% set wait_lbl = item.wait_seconds ~ "s" %}
+      {% elif item.wait_seconds < 3600 %}
+        {% set wait_lbl = (item.wait_seconds // 60) ~ "m" %}
+      {% else %}
+        {% set wait_lbl = (item.wait_seconds // 3600) ~ "h" %}
+      {% endif %}
+
+      <div class="attn-item">
+        <div class="attn-type-ico {{ type_cls }}">{{ icon }}</div>
+        <div class="attn-info">
+          <div class="attn-top-row">
+            {% if item.ticket_id %}<span class="attn-tid">{{ item.ticket_id }}</span>{% endif %}
+            <span class="attn-lbl">{{ item.title }}</span>
+          </div>
+          <div class="attn-desc">{{ item.description }}</div>
+        </div>
+        <div class="attn-meta">
+          {% if item.step_name %}
+            {% if item.step_name == "plan" %}
+              {% set step_cls = "stp-pl" %}
+            {% elif item.step_name == "build" %}
+              {% set step_cls = "stp-bu" %}
+            {% elif item.step_name in ("build-audit", "plan-audit") %}
+              {% set step_cls = "stp-ba" %}
+            {% else %}
+              {% set step_cls = "stp-cr" %}
+            {% endif %}
+            <span class="attn-step {{ step_cls }}">{{ item.step_name }}</span>
+          {% endif %}
+          <span>{{ wait_lbl }}</span>
+        </div>
+        <button class="attn-btn {{ btn_cls }}">{{ btn_lbl }}</button>
+      </div>
+    {% endfor %}
+  </div>
+</details>
+{% endif %}
+</div>

--- a/src/zing_ai/server/templates/fragments/attention_bar.html
+++ b/src/zing_ai/server/templates/fragments/attention_bar.html
@@ -5,21 +5,22 @@
     attention_items  — list[AttentionItem] from build_attention_queue()
 
   Hidden entirely when attention_items is empty.
-  Collapsible via <details>/<summary> — preserves open/closed state across SSE patches.
+  Collapse state is tracked in the Datastar signal $attnBarOpen so it
+  survives SSE patches that replace this element in-place.
 
   The outer <div id="attention-bar"> is included here so that OUTER-mode SSE
   patches can replace this element in-place (same pattern as kanban_board.html).
 #}
 <div id="attention-bar">
 {% if attention_items %}
-<details class="attn-bar" open>
-  <summary class="attn-hdr">
+<div class="attn-bar">
+  <div class="attn-hdr" data-on-click="$attnBarOpen = !$attnBarOpen" style="cursor:pointer">
     <div class="attn-ico">!</div>
     <span class="attn-ttl">Needs your attention</span>
     <span class="attn-cnt">{{ attention_items | length }}</span>
     <span class="attn-chv">&#9660;</span>
-  </summary>
-  <div class="attn-items">
+  </div>
+  <div class="attn-items" data-show="$attnBarOpen">
     {% for item in attention_items %}
       {% if item.action_type == "findings" %}
         {% set type_cls = "type-findings" %}
@@ -79,6 +80,6 @@
       </div>
     {% endfor %}
   </div>
-</details>
+</div>
 {% endif %}
 </div>

--- a/src/zing_ai/server/templates/fragments/drawer_attach.html
+++ b/src/zing_ai/server/templates/fragments/drawer_attach.html
@@ -1,0 +1,121 @@
+{#
+  drawer_attach.html — attach-mode content for ClaudeCodeSession items.
+
+  Expected context variables:
+    session          — ClaudeCodeSession
+    notification     — Notification object (the pending question)
+    queue_position   — current position in queue (int)
+    queue_total      — total items in queue (int)
+    queue_items      — remaining attention items
+    next_session_id  — session_id of next item (or None)
+    prev_session_id  — session_id of previous item (or None)
+    waiting_label    — human-readable wait time (e.g. "5m")
+#}
+
+{# ── Backdrop ── #}
+<div class="drawer-backdrop" onclick="window.closeReviewDrawer()"></div>
+
+{# ── Drawer panel ── #}
+<div class="drawer" id="review-drawer">
+
+  {# ── Header ── #}
+  <div class="dh">
+    <div class="dh-top">
+      <button class="dh-close" onclick="window.closeReviewDrawer()">&times;</button>
+      {% if session.ticket_id %}
+        <span class="dh-ticket">{{ session.ticket_id }}</span>
+      {% endif %}
+      <div class="dh-nav">
+        <span class="dh-nav-lbl">{{ queue_position }} of {{ queue_total }}</span>
+        <button class="dh-nav-btn" onclick="window.drawerNavPrev()" title="Previous"
+          {% if not prev_session_id %}disabled{% endif %}>&larr;</button>
+        <button class="dh-nav-btn" onclick="window.drawerNavNext()" title="Next"
+          {% if not next_session_id %}disabled{% endif %}>&rarr;</button>
+      </div>
+    </div>
+    <div class="dh-title">{{ session.title }}</div>
+    <div class="dh-meta">
+      <span class="dh-badge badge-cyan">attach</span>
+      {% if waiting_label %}
+        <span>waiting {{ waiting_label }}</span>
+      {% endif %}
+    </div>
+  </div>
+
+  {# ── No timeline for attach mode ── #}
+
+  {# ── Scrollable body ── #}
+  <div class="d-body" id="drawer-body">
+
+    {# ── Blue hero card ── #}
+    <div class="attach-hero">
+      <div class="attach-hero-icon">&#9654;</div>
+      <h3>Claude needs your input</h3>
+      {% if notification %}
+        <p>{{ notification.body }}</p>
+      {% endif %}
+      <button class="attach-hero-btn"
+        onclick="window.openTerminalFromDrawer('{{ session.session_id }}')">
+        Attach to Session
+      </button>
+    </div>
+
+    {# ── Question text ── #}
+    {% if notification and notification.body %}
+      <div class="attach-ctx">
+        <div class="attach-ctx-title">Question from Claude</div>
+        <div class="attach-msg">{{ notification.body }}</div>
+      </div>
+    {% endif %}
+
+  </div>
+
+  {# ── Footer ── #}
+  <div class="d-footer">
+    <div class="d-fprog">Waiting for your response</div>
+    <button class="d-fskip" onclick="window.skipToNext()">Skip &rarr;</button>
+  </div>
+
+  {# ── Up next queue ── #}
+  {% if queue_items %}
+    <div class="d-queue"
+      data-next-session-id="{{ next_session_id or '' }}"
+      data-prev-session-id="{{ prev_session_id or '' }}">
+      <div class="d-qt">Up next <span class="d-qc">{{ queue_items | length }}</span></div>
+      {% for item in queue_items[:3] %}
+        {% if item.action_type == "findings" %}
+          {% set qi_cls = "qi-findings" %}
+          {% set qi_ico = "&#9998;" %}
+          {% set qa_cls = "qa-review" %}
+          {% set qa_lbl = "review" %}
+        {% elif item.action_type == "attach" %}
+          {% set qi_cls = "qi-attach" %}
+          {% set qi_ico = "&#9654;" %}
+          {% set qa_cls = "qa-attach" %}
+          {% set qa_lbl = "attach" %}
+        {% else %}
+          {% set qi_cls = "qi-question" %}
+          {% set qi_ico = "?" %}
+          {% set qa_cls = "qa-answer" %}
+          {% set qa_lbl = "answer" %}
+        {% endif %}
+        <div class="d-qi"
+             onclick="window.openReviewDrawer('{{ item.session_id }}', '{{ item.action_type }}')"
+             data-session-id="{{ item.session_id }}">
+          <div class="d-qi-ico {{ qi_cls }}">{{ qi_ico }}</div>
+          {% if item.ticket_id %}<span class="d-qid">{{ item.ticket_id }}</span>{% endif %}
+          <span class="d-qtl">{{ item.title }}</span>
+          <span class="d-qa {{ qa_cls }}">{{ qa_lbl }}</span>
+        </div>
+      {% endfor %}
+    </div>
+  {% else %}
+    <div class="d-queue">
+      <div class="d-qt">Queue empty</div>
+      <div style="font-size:0.68rem;color:var(--gray-500);padding:0.25rem 0.25rem 0.1rem">
+        All caught up &#10003;
+      </div>
+    </div>
+  {% endif %}
+
+</div>

--- a/src/zing_ai/server/templates/fragments/drawer_attach.html
+++ b/src/zing_ai/server/templates/fragments/drawer_attach.html
@@ -55,7 +55,7 @@
         <p>{{ notification.body }}</p>
       {% endif %}
       <button class="attach-hero-btn"
-        onclick="window.openTerminalFromDrawer('{{ session.session_id }}')">
+        onclick="window.openTerminalFromDrawer('{{ session.terminal_session }}')">
         Attach to Session
       </button>
     </div>

--- a/src/zing_ai/server/templates/fragments/drawer_step_history.html
+++ b/src/zing_ai/server/templates/fragments/drawer_step_history.html
@@ -1,0 +1,68 @@
+{#
+  drawer_step_history.html — a single collapsible step history section for the review drawer.
+
+  Expected context variables:
+    step     — WorkflowStep object
+    session  — the parent session (for session_id)
+
+  Rendered per-step via the GET /command-center/drawer/{session_id}/step/{step_id} route.
+#}
+<div class="step-section" id="step-section-{{ step.step_id }}">
+  <div class="step-hdr" onclick="this.parentElement.classList.toggle('open')">
+    <span class="step-chv">&#9654;</span>
+    {% if step.step_name == "plan" %}
+      <span class="step-ico">&#128269;</span>
+    {% elif step.step_name in ("plan-audit", "build-audit") %}
+      <span class="step-ico">&#128203;</span>
+    {% elif step.step_name == "build" %}
+      <span class="step-ico">&#128736;</span>
+    {% elif step.step_name == "code-review" %}
+      <span class="step-ico">&#128270;</span>
+    {% else %}
+      <span class="step-ico">&#9654;</span>
+    {% endif %}
+    <span class="step-name">{{ step.step_name }}</span>
+    {% if step.state.value == "completed" %}
+      <span class="step-badge sbg-completed">completed</span>
+    {% elif step.state.value == "ready" %}
+      <span class="step-badge sbg-ready">ready</span>
+    {% else %}
+      <span class="step-badge sbg-started">{{ step.state.value }}</span>
+    {% endif %}
+    {% if step.agents %}
+      <span class="step-time">{{ step.agents | length }} agent{% if step.agents | length != 1 %}s{% endif %}</span>
+    {% endif %}
+  </div>
+  <div class="step-content">
+    {# Agent rows #}
+    {% for agent in step.agents %}
+      <div class="agent-row">
+        <div class="ag-dot" style="background:{% if agent.state.value == 'completed' %}var(--green){% else %}var(--orange){% endif %}"></div>
+        <span class="ag-name">{{ agent.name }}</span>
+        {% if agent.description %}<span class="ag-desc">— {{ agent.description }}</span>{% endif %}
+      </div>
+    {% endfor %}
+
+    {# Per-finding response rows #}
+    {% if step.findings %}
+      <div class="hist-findings">
+        {% for finding in step.findings %}
+          {% set response = step.responses[loop.index0] if step.responses and loop.index0 < step.responses | length else None %}
+          <div class="hist-finding">
+            {% if response and response.action %}
+              <span class="hf-action hfa-{{ response.action.value | lower }}">{{ response.action.value }}</span>
+            {% else %}
+              <span class="hf-action" style="background:var(--gray-100);color:var(--gray-500)">—</span>
+            {% endif %}
+            <div class="hf-body">
+              <div class="hf-title {% if response and response.action and response.action.value == 'drop' %}hf-dropped{% endif %}">{{ finding.title }}</div>
+              {% if response and response.answer %}
+                <div class="hf-response">{{ response.answer }}</div>
+              {% endif %}
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+</div>

--- a/src/zing_ai/server/templates/fragments/kanban_card.html
+++ b/src/zing_ai/server/templates/fragments/kanban_card.html
@@ -371,23 +371,28 @@
       {% set _status_label = "done" if _state_val == "completed" else ("stopped" if _state_val == "stopped" else _state_val) %}
       <div class="card-session-strip" data-open-drawer="{{ _sess.session_id }}" data-drawer-mode="history">
         <div class="card-session-phases">
-          {# Phase segments rendered inline — build_session_phases() not callable from template,
-             so we render simple phase segments from step names directly ── #}
-          {% for step in _sess.steps %}
-            {% if step.step_name == 'plan' %}
-              <div class="css-seg css-p" style="flex:1"></div>
-            {% elif step.step_name in ('plan-audit', 'build-audit', 'pr-audit', 'custom-audit') %}
-              <div class="css-seg css-a" style="flex:1"></div>
-            {% elif step.step_name == 'build' %}
-              <div class="css-seg css-b" style="flex:1"></div>
-            {% elif step.step_name == 'ready' %}
-              <div class="css-seg css-r" style="flex:1"></div>
-            {% else %}
-              <div class="css-seg css-b" style="flex:1"></div>
+          {% if session_phases and _sess.session_id in session_phases %}
+            {% for seg in session_phases[_sess.session_id] %}
+              <div class="css-seg css-{{ seg.phase[0] }}" style="flex:{{ seg.flex }}"></div>
+            {% endfor %}
+          {% else %}
+            {# Phase segments rendered inline — equal-width fallback ── #}
+            {% for step in _sess.steps %}
+              {% if step.step_name == 'plan' %}
+                <div class="css-seg css-p" style="flex:1"></div>
+              {% elif step.step_name in ('plan-audit', 'build-audit', 'pr-audit', 'custom-audit') %}
+                <div class="css-seg css-a" style="flex:1"></div>
+              {% elif step.step_name == 'build' %}
+                <div class="css-seg css-b" style="flex:1"></div>
+              {% elif step.step_name == 'ready' %}
+                <div class="css-seg css-r" style="flex:1"></div>
+              {% else %}
+                <div class="css-seg css-b" style="flex:1"></div>
+              {% endif %}
+            {% endfor %}
+            {% if not _sess.steps %}
+              <div class="css-seg css-w" style="flex:1"></div>
             {% endif %}
-          {% endfor %}
-          {% if not _sess.steps %}
-            <div class="css-seg css-w" style="flex:1"></div>
           {% endif %}
         </div>
         <span class="card-session-label">{{ _status_label }}</span>

--- a/src/zing_ai/server/templates/fragments/kanban_card.html
+++ b/src/zing_ai/server/templates/fragments/kanban_card.html
@@ -12,6 +12,23 @@
   {% set total_findings.count = total_findings.count + step.findings | length %}
 {% endfor %}
 
+{# ── Compute card_has_active_action:
+     True if any ZingSession has a READY step (audit findings waiting),
+     OR any ClaudeCodeSession has a pending (unanswered) question. ── #}
+{% set _active_action = namespace(found=false) %}
+{% for session in card.sessions %}
+  {% if session.session_type == 'zing' %}
+    {% for step in session.steps %}
+      {% if step.state.value == 'ready' %}
+        {% set _active_action.found = true %}
+      {% endif %}
+    {% endfor %}
+  {% elif session.session_type == 'claude_code' and session.pending_question %}
+    {% set _active_action.found = true %}
+  {% endif %}
+{% endfor %}
+{% set card_has_active_action = _active_action.found %}
+
 <div class="card {{ card_extra_cls | default('') }}" id="card-{{ card.key | lower | replace('/', '-') }}">
 
   {# ── Header: ticket ID + title + assignee ── #}
@@ -241,6 +258,15 @@
     </div>
   {% endfor %}
 
+  {# ── Blue attach strip: ClaudeCodeSession with a pending question ── #}
+  {% for session in card.sessions if session.session_type == 'claude_code' and session.pending_question %}
+    <div class="card-attach-strip">
+      <span class="card-attach-dot"></span>
+      <span class="card-attach-text">{{ session.pending_question.body | truncate(60) }}</span>
+      <button class="card-attach-btn" data-open-drawer="{{ session.session_id }}">Attach</button>
+    </div>
+  {% endfor %}
+
   {# ── Findings + waiting note ── #}
   {% if total_findings.count > 0 or (column_cls == "col-review" and card.review_group == "others") %}
     <div class="status-strip">
@@ -332,6 +358,52 @@
     </div>
   {% elif card.prs and column_cls == "col-progress" %}
     {# PR cards in progress: setup env button moved to PR kebab menu, no standalone footer needed #}
+  {% endif %}
+
+  {# ── Session history strip: shown when there are sessions but NO active action ── #}
+  {% if card.sessions and not card_has_active_action %}
+    {# Find the first ZingSession (for phases) or fall back to any session ── #}
+    {% set _zing_sessions = card.sessions | selectattr("session_type", "equalto", "zing") | list %}
+    {% if _zing_sessions %}
+      {% set _sess = _zing_sessions[0] %}
+      {# Compute elapsed: difference between now (via created_at of last step, or session) and session start ── #}
+      {% set _state_val = _sess.state.value %}
+      {% set _status_label = "done" if _state_val == "completed" else ("stopped" if _state_val == "stopped" else _state_val) %}
+      <div class="card-session-strip" data-open-drawer="{{ _sess.session_id }}" data-drawer-mode="history">
+        <div class="card-session-phases">
+          {# Phase segments rendered inline — build_session_phases() not callable from template,
+             so we render simple phase segments from step names directly ── #}
+          {% for step in _sess.steps %}
+            {% if step.step_name == 'plan' %}
+              <div class="css-seg css-p" style="flex:1"></div>
+            {% elif step.step_name in ('plan-audit', 'build-audit', 'pr-audit', 'custom-audit') %}
+              <div class="css-seg css-a" style="flex:1"></div>
+            {% elif step.step_name == 'build' %}
+              <div class="css-seg css-b" style="flex:1"></div>
+            {% elif step.step_name == 'ready' %}
+              <div class="css-seg css-r" style="flex:1"></div>
+            {% else %}
+              <div class="css-seg css-b" style="flex:1"></div>
+            {% endif %}
+          {% endfor %}
+          {% if not _sess.steps %}
+            <div class="css-seg css-w" style="flex:1"></div>
+          {% endif %}
+        </div>
+        <span class="card-session-label">{{ _status_label }}</span>
+        <span class="card-session-view">View session &rarr;</span>
+      </div>
+    {% elif card.sessions %}
+      {# ClaudeCodeSession with history but no active action ── #}
+      {% set _sess = card.sessions[0] %}
+      <div class="card-session-strip" data-open-drawer="{{ _sess.session_id }}" data-drawer-mode="history">
+        <div class="card-session-phases">
+          <div class="css-seg css-b" style="flex:1"></div>
+        </div>
+        <span class="card-session-label">session</span>
+        <span class="card-session-view">View session &rarr;</span>
+      </div>
+    {% endif %}
   {% endif %}
 
 </div>

--- a/src/zing_ai/server/templates/fragments/review_drawer.html
+++ b/src/zing_ai/server/templates/fragments/review_drawer.html
@@ -1,0 +1,308 @@
+{#
+  review_drawer.html — full drawer shell injected into #review-drawer-container.
+
+  Expected context variables:
+    session       — ZingSession or ClaudeCodeSession
+    steps         — list of WorkflowStep objects (completed + current)
+    current_step  — the WorkflowStep that is current (READY or STARTED)
+    current_step_index — 0-based index of current step (for timeline)
+    mode          — "findings" | "attach"
+    queue_position — "N of M" position in attention queue
+    queue_total   — total items in attention queue
+    queue_items   — remaining attention items after this one
+    next_session_id — session_id of next item (or None)
+    prev_session_id — session_id of previous item (or None)
+
+  The outer drawer-backdrop and .drawer are rendered inline.
+  The step history is included via a separate fragment call.
+#}
+
+{# ── Backdrop ── #}
+<div class="drawer-backdrop" onclick="window.closeReviewDrawer()"></div>
+
+{# ── Drawer panel ── #}
+<div class="drawer" id="review-drawer">
+
+  {# ── Header ── #}
+  <div class="dh">
+    <div class="dh-top">
+      <button class="dh-close" onclick="window.closeReviewDrawer()">&times;</button>
+      {% if session.ticket_id %}
+        <span class="dh-ticket">{{ session.ticket_id }}</span>
+      {% endif %}
+      <div class="dh-nav">
+        <span class="dh-nav-lbl">{{ queue_position }} of {{ queue_total }}</span>
+        <button class="dh-nav-btn" onclick="window.drawerNavPrev()" title="Previous"
+          {% if not prev_session_id %}disabled{% endif %}>&larr;</button>
+        <button class="dh-nav-btn" onclick="window.drawerNavNext()" title="Next"
+          {% if not next_session_id %}disabled{% endif %}>&rarr;</button>
+      </div>
+    </div>
+    <div class="dh-title">{{ session.title }}</div>
+    <div class="dh-meta">
+      {% if current_step %}
+        <span class="dh-badge badge-cyan">{{ current_step.step_name }}</span>
+        {% if mode == "findings" %}
+          <span>{{ current_step.findings | length }} finding{% if current_step.findings | length != 1 %}s{% endif %}</span>
+        {% endif %}
+      {% endif %}
+      {% if waiting_label %}
+        <span>waiting {{ waiting_label }}</span>
+      {% endif %}
+    </div>
+  </div>
+
+  {# ── Timeline bar ── #}
+  {% if steps %}
+    <div class="d-tl">
+      {% for step in steps %}
+        {% if step.state.value == "completed" %}
+          {% if step.step_name == "plan" %}
+            <div class="ds ds-p" style="flex:{{ loop.index }}" title="{{ step.step_name }}">{{ step.step_name }}</div>
+          {% elif step.step_name in ("plan-audit", "build-audit") %}
+            <div class="ds ds-a" style="flex:{{ loop.index }}" title="{{ step.step_name }}">{{ step.step_name }}</div>
+          {% elif step.step_name == "build" %}
+            <div class="ds ds-b" style="flex:{{ loop.index }}" title="{{ step.step_name }}">{{ step.step_name }}</div>
+          {% elif step.step_name == "code-review" %}
+            <div class="ds ds-r" style="flex:{{ loop.index }}" title="{{ step.step_name }}">{{ step.step_name }}</div>
+          {% else %}
+            <div class="ds ds-u" style="flex:{{ loop.index }}" title="{{ step.step_name }}">{{ step.step_name }}</div>
+          {% endif %}
+        {% elif step.state.value == "ready" %}
+          <div class="ds ds-wn" style="flex:{{ loop.index }}" title="{{ step.step_name }}">now</div>
+        {% else %}
+          <div class="ds ds-w" style="flex:{{ loop.index }}" title="{{ step.step_name }}"></div>
+        {% endif %}
+      {% endfor %}
+    </div>
+    <div class="d-tl-info">
+      <span style="font-weight:600">{{ steps | length }} step{% if steps | length != 1 %}s{% endif %}</span>
+    </div>
+  {% endif %}
+
+  {# ── Scrollable body ── #}
+  <div class="d-body" id="drawer-body">
+    {# Past steps — collapsible history #}
+    {% for step in steps %}
+      {% if step != current_step %}
+        <div class="step-section" id="step-section-{{ step.step_id }}">
+          <div class="step-hdr" onclick="this.parentElement.classList.toggle('open')">
+            <span class="step-chv">&#9654;</span>
+            {% if step.step_name == "plan" %}
+              <span class="step-ico">&#128269;</span>
+            {% elif step.step_name in ("plan-audit", "build-audit") %}
+              <span class="step-ico">&#128203;</span>
+            {% elif step.step_name == "build" %}
+              <span class="step-ico">&#128736;</span>
+            {% elif step.step_name == "code-review" %}
+              <span class="step-ico">&#128270;</span>
+            {% else %}
+              <span class="step-ico">&#9654;</span>
+            {% endif %}
+            <span class="step-name">{{ step.step_name }}</span>
+            {% if step.state.value == "completed" %}
+              <span class="step-badge sbg-completed">completed</span>
+            {% elif step.state.value == "ready" %}
+              <span class="step-badge sbg-ready">ready</span>
+            {% else %}
+              <span class="step-badge sbg-started">{{ step.state.value }}</span>
+            {% endif %}
+            {% if step.agents %}
+              <span class="step-time">{{ step.agents | length }} agent{% if step.agents | length != 1 %}s{% endif %}</span>
+            {% endif %}
+          </div>
+          <div class="step-content">
+            {# Agent rows #}
+            {% for agent in step.agents %}
+              <div class="agent-row">
+                <div class="ag-dot" style="background:{% if agent.state.value == 'completed' %}var(--green){% else %}var(--orange){% endif %}"></div>
+                <span class="ag-name">{{ agent.name }}</span>
+                {% if agent.description %}<span class="ag-desc">— {{ agent.description }}</span>{% endif %}
+              </div>
+            {% endfor %}
+
+            {# Per-finding response rows #}
+            {% if step.findings %}
+              <div class="hist-findings">
+                {% for finding in step.findings %}
+                  {% set response = step.responses[loop.index0] if step.responses and loop.index0 < step.responses | length else None %}
+                  <div class="hist-finding">
+                    {% if response and response.action %}
+                      <span class="hf-action hfa-{{ response.action.value | lower }}">{{ response.action.value }}</span>
+                    {% else %}
+                      <span class="hf-action" style="background:var(--gray-100);color:var(--gray-500)">—</span>
+                    {% endif %}
+                    <div class="hf-body">
+                      <div class="hf-title {% if response and response.action and response.action.value == 'drop' %}hf-dropped{% endif %}">{{ finding.title }}</div>
+                      {% if response and response.answer %}
+                        <div class="hf-response">{{ response.answer }}</div>
+                      {% endif %}
+                    </div>
+                  </div>
+                {% endfor %}
+              </div>
+            {% endif %}
+          </div>
+        </div>
+      {% endif %}
+    {% endfor %}
+
+    {# Current step findings or attach mode #}
+    {% if current_step %}
+      {% if mode == "attach" %}
+        {# ── Attach hero ── #}
+        <div class="attach-hero">
+          <div class="attach-hero-icon">&#9654;</div>
+          <h3>Claude needs your input</h3>
+          {% if notification_body %}
+            <p>{{ notification_body }}</p>
+          {% endif %}
+          <button class="attach-hero-btn" onclick="window.openTerminalFromDrawer('{{ session.session_id }}')">Attach to Session</button>
+        </div>
+
+        {% if notification_body %}
+          <div class="attach-ctx">
+            <div class="attach-ctx-title">Question</div>
+            <div class="attach-msg">{{ notification_body }}</div>
+          </div>
+        {% endif %}
+
+      {% elif mode == "findings" and current_step.findings %}
+        {# ── Current step header ── #}
+        <div class="step-section open" id="step-section-{{ current_step.step_id }}">
+          <div class="step-hdr" style="background:rgba(62,207,224,0.06)" onclick="this.parentElement.classList.toggle('open')">
+            <span class="step-chv">&#9654;</span>
+            {% if current_step.step_name == "plan" %}
+              <span class="step-ico">&#128269;</span>
+            {% elif current_step.step_name in ("plan-audit", "build-audit") %}
+              <span class="step-ico">&#128203;</span>
+            {% elif current_step.step_name == "build" %}
+              <span class="step-ico">&#128736;</span>
+            {% elif current_step.step_name == "code-review" %}
+              <span class="step-ico">&#128270;</span>
+            {% else %}
+              <span class="step-ico">&#9654;</span>
+            {% endif %}
+            <span class="step-name">{{ current_step.step_name }}</span>
+            <span class="step-badge sbg-ready">ready for review</span>
+          </div>
+          <div class="step-content">
+            {% for agent in current_step.agents %}
+              <div class="agent-row">
+                <div class="ag-dot"></div>
+                <span class="ag-name">{{ agent.name }}</span>
+                {% if agent.description %}<span class="ag-desc">— {{ agent.description }}</span>{% endif %}
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+
+        {# ── Findings area ── #}
+        <div class="findings-area">
+          <div class="d-ft">Findings to review ({{ current_step.findings | length }})</div>
+
+          {% for finding in current_step.findings %}
+            <div class="df" id="df-{{ finding.id }}">
+              <div class="df-h">
+                {% if finding.type == "triage" and finding.severity %}
+                  {% if finding.severity.value in ("critical", "high") %}
+                    <span class="df-s df-hi">{{ finding.severity.value }}</span>
+                  {% elif finding.severity.value == "medium" %}
+                    <span class="df-s df-me">med</span>
+                  {% else %}
+                    <span class="df-s df-in">{{ finding.severity.value }}</span>
+                  {% endif %}
+                {% elif finding.type == "evaluation" %}
+                  <span class="df-s df-in">eval</span>
+                {% elif finding.type == "text" %}
+                  <span class="df-s" style="background:rgba(245,124,32,0.15);color:var(--orange)">q</span>
+                {% endif %}
+                <span class="df-t">{{ finding.title }}</span>
+              </div>
+              {% if finding.body %}
+                <div class="df-b">{{ finding.body }}</div>
+              {% endif %}
+              {% if finding.type == "triage" and finding.location %}
+                <div class="df-l">{{ finding.location.file }}{% if finding.location.line %}:{{ finding.location.line }}{% endif %}</div>
+              {% endif %}
+              {% if finding.type == "triage" %}
+                <div class="df-tr">
+                  <button class="df-tb" data-action="accept" data-finding-id="{{ finding.id }}" data-step-id="{{ current_step.step_id }}" data-session-id="{{ session.session_id }}" onclick="window.drawerTriage(this)">Accept</button>
+                  <button class="df-tb" data-action="drop" data-finding-id="{{ finding.id }}" data-step-id="{{ current_step.step_id }}" data-session-id="{{ session.session_id }}" onclick="window.drawerTriage(this)">Drop</button>
+                  <button class="df-tb" data-action="discuss" data-finding-id="{{ finding.id }}" data-step-id="{{ current_step.step_id }}" data-session-id="{{ session.session_id }}" onclick="window.drawerTriage(this)">Discuss</button>
+                </div>
+              {% elif finding.type == "text" %}
+                <div class="df-tr">
+                  <textarea class="df-answer" id="answer-{{ finding.id }}" placeholder="Your answer…" rows="2"
+                    data-finding-id="{{ finding.id }}" data-step-id="{{ current_step.step_id }}" data-session-id="{{ session.session_id }}"></textarea>
+                </div>
+              {% endif %}
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endif %}
+  </div>
+
+  {# ── Footer ── #}
+  <div class="d-footer">
+    <div class="d-fprog">
+      {% if mode == "findings" and current_step %}
+        <strong id="drawer-triage-count">0</strong> / {{ current_step.findings | length }} triaged
+      {% elif mode == "attach" %}
+        Waiting for response
+      {% endif %}
+    </div>
+    <button class="d-fskip" onclick="window.skipToNext()">Skip &rarr;</button>
+    {% if mode == "findings" and current_step %}
+      <button class="d-fsub"
+        id="drawer-submit-btn"
+        data-session-id="{{ session.session_id }}"
+        data-step-id="{{ current_step.step_id }}"
+        data-next-session-id="{{ next_session_id or '' }}"
+        onclick="window.submitAndNext()">Submit &amp; Next</button>
+    {% endif %}
+  </div>
+
+  {# ── Up next queue ── #}
+  {% if queue_items %}
+    <div class="d-queue"
+      data-next-session-id="{{ next_session_id or '' }}"
+      data-prev-session-id="{{ prev_session_id or '' }}">
+      <div class="d-qt">Up next <span class="d-qc">{{ queue_items | length }}</span></div>
+      {% for item in queue_items[:3] %}
+        {% if item.action_type == "findings" %}
+          {% set qi_cls = "qi-findings" %}
+          {% set qi_ico = "&#9998;" %}
+          {% set qa_cls = "qa-review" %}
+          {% set qa_lbl = "review" %}
+        {% elif item.action_type == "attach" %}
+          {% set qi_cls = "qi-attach" %}
+          {% set qi_ico = "&#9654;" %}
+          {% set qa_cls = "qa-attach" %}
+          {% set qa_lbl = "attach" %}
+        {% else %}
+          {% set qi_cls = "qi-question" %}
+          {% set qi_ico = "?" %}
+          {% set qa_cls = "qa-answer" %}
+          {% set qa_lbl = "answer" %}
+        {% endif %}
+        <div class="d-qi" onclick="window.openReviewDrawer('{{ item.session_id }}', '{{ item.action_type }}')"
+             data-session-id="{{ item.session_id }}">
+          <div class="d-qi-ico {{ qi_cls }}">{{ qi_ico }}</div>
+          {% if item.ticket_id %}<span class="d-qid">{{ item.ticket_id }}</span>{% endif %}
+          <span class="d-qtl">{{ item.title }}</span>
+          <span class="d-qa {{ qa_cls }}">{{ qa_lbl }}</span>
+        </div>
+      {% endfor %}
+    </div>
+  {% else %}
+    <div class="d-queue">
+      <div class="d-qt">Queue empty</div>
+      <div style="font-size:0.68rem;color:var(--gray-500);padding:0.25rem 0.25rem 0.1rem">
+        All caught up &#10003;
+      </div>
+    </div>
+  {% endif %}
+
+</div>

--- a/src/zing_ai/server/templates/fragments/review_drawer.html
+++ b/src/zing_ai/server/templates/fragments/review_drawer.html
@@ -157,7 +157,7 @@
           {% if notification_body %}
             <p>{{ notification_body }}</p>
           {% endif %}
-          <button class="attach-hero-btn" onclick="window.openTerminalFromDrawer('{{ session.session_id }}')">Attach to Session</button>
+          <button class="attach-hero-btn" onclick="window.openTerminalFromDrawer('{{ session.terminal_session }}')">Attach to Session</button>
         </div>
 
         {% if notification_body %}

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -1,0 +1,285 @@
+"""Tests for the attention queue logic."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime
+
+from zing_ai.server.attention import build_attention_queue
+from zing_ai.server.models import (
+    ClaudeCodeSession,
+    Notification,
+    SessionState,
+    TextFinding,
+    WorkflowStep,
+    ZingSession,
+)
+
+
+def _make_zing_session(
+    session_id: str = "sess-1",
+    title: str = "Test Session",
+    ticket_id: str | None = "TKT-1",
+    steps: list[WorkflowStep] | None = None,
+) -> ZingSession:
+    return ZingSession(
+        session_id=session_id,
+        title=title,
+        ticket_id=ticket_id,
+        steps=steps or [],
+    )
+
+
+def _make_step(
+    step_name: str,
+    state: SessionState,
+    created_at: datetime,
+    findings: list | None = None,
+) -> WorkflowStep:
+    return WorkflowStep(
+        step_name=step_name,
+        sequence=0,
+        state=state,
+        created_at=created_at,
+        findings=findings or [],
+    )
+
+
+def _make_claude_session(
+    session_id: str = "cc-1",
+    title: str = "Claude Session",
+    ticket_id: str | None = None,
+    notifications: list[Notification] | None = None,
+) -> ClaudeCodeSession:
+    return ClaudeCodeSession(
+        session_id=session_id,
+        title=title,
+        ticket_id=ticket_id,
+        notifications=notifications or [],
+    )
+
+
+def _make_notification(
+    body: str = "What should I do?",
+    created_at: datetime | None = None,
+    answered_at: datetime | None = None,
+) -> Notification:
+    return Notification(
+        title="Question",
+        body=body,
+        created_at=created_at or datetime(2026, 1, 1, 12, 0, 0),
+        answered_at=answered_at,
+    )
+
+
+class TestZingSessionFindings(unittest.TestCase):
+    """ZingSession with a READY step produces a findings AttentionItem."""
+
+    def test_ready_audit_step_produces_findings_item(self) -> None:
+        now = datetime(2026, 1, 1, 12, 10, 0)
+        step_created = datetime(2026, 1, 1, 12, 0, 0)
+        finding = TextFinding(title="Issue found")
+        step = _make_step("build-audit", SessionState.READY, step_created, [finding])
+        session = _make_zing_session(steps=[step])
+
+        items = build_attention_queue([session], now)
+
+        assert len(items) == 1
+        item = items[0]
+        assert item.action_type == "findings"
+        assert item.session_id == "sess-1"
+        assert item.ticket_id == "TKT-1"
+        assert item.title == "Test Session"
+        assert item.step_name == "build-audit"
+        assert item.finding_count == 1
+        assert item.wait_seconds == 600
+        assert item.card_key == "sess-1"
+
+    def test_plan_step_produces_questions_item(self) -> None:
+        now = datetime(2026, 1, 1, 12, 5, 0)
+        step_created = datetime(2026, 1, 1, 12, 0, 0)
+        step = _make_step("plan", SessionState.READY, step_created)
+        session = _make_zing_session(steps=[step])
+
+        items = build_attention_queue([session], now)
+
+        assert len(items) == 1
+        assert items[0].action_type == "questions"
+
+    def test_plan_audit_step_produces_findings_not_questions(self) -> None:
+        now = datetime(2026, 1, 1, 12, 5, 0)
+        step_created = datetime(2026, 1, 1, 12, 0, 0)
+        step = _make_step("plan-audit", SessionState.READY, step_created)
+        session = _make_zing_session(steps=[step])
+
+        items = build_attention_queue([session], now)
+
+        assert len(items) == 1
+        assert items[0].action_type == "findings"
+
+
+class TestClaudeCodeSessionAttach(unittest.TestCase):
+    """ClaudeCodeSession with a pending notification produces an attach AttentionItem."""
+
+    def test_pending_notification_produces_attach_item(self) -> None:
+        now = datetime(2026, 1, 1, 12, 10, 0)
+        notif = _make_notification(
+            body="Should I refactor this?",
+            created_at=datetime(2026, 1, 1, 12, 0, 0),
+        )
+        session = _make_claude_session(
+            session_id="cc-1",
+            ticket_id="TKT-2",
+            notifications=[notif],
+        )
+
+        items = build_attention_queue([session], now)
+
+        assert len(items) == 1
+        item = items[0]
+        assert item.action_type == "attach"
+        assert item.session_id == "cc-1"
+        assert item.ticket_id == "TKT-2"
+        assert item.description == "Should I refactor this?"
+        assert item.step_name is None
+        assert item.finding_count == 0
+        assert item.wait_seconds == 600
+        assert item.card_key == "cc-1"
+
+    def test_latest_unanswered_notification_used(self) -> None:
+        now = datetime(2026, 1, 1, 12, 10, 0)
+        older = _make_notification(
+            body="Older question",
+            created_at=datetime(2026, 1, 1, 12, 0, 0),
+        )
+        newer = _make_notification(
+            body="Newer question",
+            created_at=datetime(2026, 1, 1, 12, 5, 0),
+        )
+        session = _make_claude_session(notifications=[older, newer])
+
+        items = build_attention_queue([session], now)
+
+        assert len(items) == 1
+        # pending_question returns the last unanswered notification
+        assert items[0].description == "Newer question"
+        assert items[0].wait_seconds == 300
+
+
+class TestQueueSorting(unittest.TestCase):
+    """Queue is sorted by wait_seconds descending."""
+
+    def test_sorted_by_wait_descending(self) -> None:
+        now = datetime(2026, 1, 1, 12, 30, 0)
+
+        # Step created 20 minutes ago -> 1200s wait
+        step_old = _make_step("build-audit", SessionState.READY, datetime(2026, 1, 1, 12, 10, 0))
+        session_old = _make_zing_session(session_id="s-old", steps=[step_old])
+
+        # Step created 5 minutes ago -> 300s wait
+        step_new = _make_step("build-audit", SessionState.READY, datetime(2026, 1, 1, 12, 25, 0))
+        session_new = _make_zing_session(session_id="s-new", steps=[step_new])
+
+        # ClaudeCode notification created 10 minutes ago -> 600s wait
+        notif = _make_notification(created_at=datetime(2026, 1, 1, 12, 20, 0))
+        session_cc = _make_claude_session(session_id="cc-mid", notifications=[notif])
+
+        items = build_attention_queue([session_new, session_cc, session_old], now)
+
+        assert len(items) == 3
+        assert items[0].session_id == "s-old"
+        assert items[0].wait_seconds == 1200
+        assert items[1].session_id == "cc-mid"
+        assert items[1].wait_seconds == 600
+        assert items[2].session_id == "s-new"
+        assert items[2].wait_seconds == 300
+
+
+class TestNoAttentionNeeded(unittest.TestCase):
+    """Sessions with no pending action produce no items."""
+
+    def test_pending_step_produces_no_item(self) -> None:
+        now = datetime(2026, 1, 1, 12, 10, 0)
+        step = _make_step("build-audit", SessionState.PENDING, datetime(2026, 1, 1, 12, 0, 0))
+        session = _make_zing_session(steps=[step])
+
+        items = build_attention_queue([session], now)
+
+        assert items == []
+
+    def test_started_step_produces_no_item(self) -> None:
+        now = datetime(2026, 1, 1, 12, 10, 0)
+        step = _make_step("build-audit", SessionState.STARTED, datetime(2026, 1, 1, 12, 0, 0))
+        session = _make_zing_session(steps=[step])
+
+        items = build_attention_queue([session], now)
+
+        assert items == []
+
+    def test_completed_step_produces_no_item(self) -> None:
+        now = datetime(2026, 1, 1, 12, 10, 0)
+        step = _make_step("build-audit", SessionState.COMPLETED, datetime(2026, 1, 1, 12, 0, 0))
+        session = _make_zing_session(steps=[step])
+
+        items = build_attention_queue([session], now)
+
+        assert items == []
+
+    def test_stopped_step_produces_no_item(self) -> None:
+        now = datetime(2026, 1, 1, 12, 10, 0)
+        step = _make_step("build-audit", SessionState.STOPPED, datetime(2026, 1, 1, 12, 0, 0))
+        session = _make_zing_session(steps=[step])
+
+        items = build_attention_queue([session], now)
+
+        assert items == []
+
+    def test_claude_session_with_all_answered_produces_no_item(self) -> None:
+        now = datetime(2026, 1, 1, 12, 10, 0)
+        notif = _make_notification(
+            answered_at=datetime(2026, 1, 1, 12, 5, 0),
+        )
+        session = _make_claude_session(notifications=[notif])
+
+        items = build_attention_queue([session], now)
+
+        assert items == []
+
+    def test_claude_session_with_no_notifications_produces_no_item(self) -> None:
+        now = datetime(2026, 1, 1, 12, 10, 0)
+        session = _make_claude_session()
+
+        items = build_attention_queue([session], now)
+
+        assert items == []
+
+    def test_zing_session_with_no_steps_produces_no_item(self) -> None:
+        now = datetime(2026, 1, 1, 12, 10, 0)
+        session = _make_zing_session(steps=[])
+
+        items = build_attention_queue([session], now)
+
+        assert items == []
+
+
+class TestCompletedSessions(unittest.TestCase):
+    """Completed sessions produce no items."""
+
+    def test_all_completed_steps_produce_no_item(self) -> None:
+        now = datetime(2026, 1, 1, 12, 10, 0)
+        step1 = _make_step("build-audit", SessionState.COMPLETED, datetime(2026, 1, 1, 12, 0, 0))
+        step2 = _make_step("plan", SessionState.COMPLETED, datetime(2026, 1, 1, 12, 0, 0))
+        session = _make_zing_session(steps=[step1, step2])
+
+        items = build_attention_queue([session], now)
+
+        assert items == []
+
+    def test_empty_session_list_returns_empty(self) -> None:
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        items = build_attention_queue([], now)
+        assert items == []
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
-from zing_ai.installer import InstallError, install_claude, install_opencode
+from zing_ai.installer import InstallError, install_claude, install_claude_hooks, install_opencode
 
 # All markdown files that should be installed, relative to the target dir.
 EXPECTED_FILES = [
@@ -572,3 +572,133 @@ def test_stale_when_stored_mtime_missing_but_current_exists(tmp_path: Path, monk
         package_version=__version__,
     )
     assert is_install_stale(tmp_path, cfg) is True
+
+
+# ---------------------------------------------------------------------------
+# Hook installation tests
+# ---------------------------------------------------------------------------
+
+
+def test_hook_script_is_installed(tmp_path: Path) -> None:
+    """install_claude_hooks() copies notify-zing.sh to the hooks directory."""
+    hooks_dir = tmp_path / "hooks"
+    settings_path = tmp_path / "settings.json"
+    install_claude_hooks(hooks_dir=hooks_dir, settings_path=settings_path)
+
+    assert (hooks_dir / "notify-zing.sh").is_file(), "notify-zing.sh not installed"
+
+
+def test_hook_script_is_executable(tmp_path: Path) -> None:
+    """notify-zing.sh must be executable after install."""
+    hooks_dir = tmp_path / "hooks"
+    settings_path = tmp_path / "settings.json"
+    install_claude_hooks(hooks_dir=hooks_dir, settings_path=settings_path)
+
+    hook = hooks_dir / "notify-zing.sh"
+    mode = hook.stat().st_mode
+    assert mode & 0o100, "notify-zing.sh is not owner-executable"
+
+
+def test_hook_script_content_matches_source(tmp_path: Path) -> None:
+    """The installed hook script content must match the bundled source."""
+    import importlib.resources
+
+    hooks_dir = tmp_path / "hooks"
+    settings_path = tmp_path / "settings.json"
+    install_claude_hooks(hooks_dir=hooks_dir, settings_path=settings_path)
+
+    src = (
+        importlib.resources.files("zing_ai")
+        .joinpath("hooks")
+        .joinpath("notify-zing.sh")
+        .read_bytes()
+    )
+    dst = (hooks_dir / "notify-zing.sh").read_bytes()
+    assert src == dst, "Installed hook content differs from source"
+
+
+def test_settings_pretooluse_entry_added(tmp_path: Path) -> None:
+    """install_claude_hooks() adds PreToolUse AskUserQuestion hook to settings.json."""
+    import json
+
+    hooks_dir = tmp_path / "hooks"
+    settings_path = tmp_path / "settings.json"
+    install_claude_hooks(hooks_dir=hooks_dir, settings_path=settings_path)
+
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    pretooluse = settings.get("hooks", {}).get("PreToolUse", [])
+    matchers = [e.get("matcher") for e in pretooluse if isinstance(e, dict)]
+    assert "AskUserQuestion" in matchers, "PreToolUse AskUserQuestion entry not found"
+
+
+def test_settings_existing_hooks_preserved(tmp_path: Path) -> None:
+    """Existing hooks in settings.json are not overwritten."""
+    import json
+
+    hooks_dir = tmp_path / "hooks"
+    settings_path = tmp_path / "settings.json"
+
+    # Write pre-existing settings with a different hook.
+    existing = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "echo hello"}],
+                }
+            ]
+        }
+    }
+    settings_path.write_text(json.dumps(existing), encoding="utf-8")
+
+    install_claude_hooks(hooks_dir=hooks_dir, settings_path=settings_path)
+
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    pretooluse = settings.get("hooks", {}).get("PreToolUse", [])
+    matchers = [e.get("matcher") for e in pretooluse if isinstance(e, dict)]
+    assert "Bash" in matchers, "Existing Bash hook was removed"
+    assert "AskUserQuestion" in matchers, "AskUserQuestion hook was not added"
+
+
+def test_settings_idempotent_no_duplicate(tmp_path: Path) -> None:
+    """Running install_claude_hooks() twice does not duplicate the PreToolUse entry."""
+    import json
+
+    hooks_dir = tmp_path / "hooks"
+    settings_path = tmp_path / "settings.json"
+
+    install_claude_hooks(hooks_dir=hooks_dir, settings_path=settings_path)
+    install_claude_hooks(hooks_dir=hooks_dir, settings_path=settings_path)
+
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    pretooluse = settings.get("hooks", {}).get("PreToolUse", [])
+    ask_entries = [
+        e for e in pretooluse if isinstance(e, dict) and e.get("matcher") == "AskUserQuestion"
+    ]
+    assert len(ask_entries) == 1, f"Expected 1 AskUserQuestion entry, found {len(ask_entries)}"
+
+
+def test_settings_created_from_scratch(tmp_path: Path) -> None:
+    """install_claude_hooks() creates settings.json if it doesn't exist."""
+    import json
+
+    hooks_dir = tmp_path / "hooks"
+    settings_path = tmp_path / "nonexistent" / "settings.json"
+
+    install_claude_hooks(hooks_dir=hooks_dir, settings_path=settings_path)
+
+    assert settings_path.exists(), "settings.json was not created"
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert "hooks" in settings
+
+
+def test_install_claude_calls_install_hooks(tmp_path: Path) -> None:
+    """install_claude() calls install_claude_hooks() as part of the install flow."""
+    target = tmp_path / "commands"
+    with (
+        patch("zing_ai.installer.install_claude_hooks") as mock_hooks,
+        patch("zing_ai.installer.register_mcp_server"),
+    ):
+        install_claude(target_dir=target)
+
+    mock_hooks.assert_called_once()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -436,6 +436,65 @@ class TestSessionDiscriminatedUnion(unittest.TestCase):
         assert session.steps[0].step_name == "review"
 
 
+class TestClaudeCodeSessionNotifications(unittest.TestCase):
+    """Tests for ClaudeCodeSession notification field."""
+
+    def test_created_with_notifications(self) -> None:
+        """ClaudeCodeSession can be created with an explicit notifications list."""
+        n = Notification(title="Hello")
+        session = ClaudeCodeSession(session_id="s1", title="T", notifications=[n])
+        assert len(session.notifications) == 1
+        assert session.notifications[0].title == "Hello"
+
+    def test_notifications_default_to_empty(self) -> None:
+        """ClaudeCodeSession notifications defaults to empty list."""
+        session = ClaudeCodeSession(session_id="s1", title="T")
+        assert session.notifications == []
+
+    def test_serialization_roundtrip(self) -> None:
+        """ClaudeCodeSession serializes and deserializes notifications correctly."""
+        from pydantic import TypeAdapter
+
+        adapter = TypeAdapter(Session)
+        n = Notification(title="Alert", body="Details", url="/s1")
+        original = ClaudeCodeSession(session_id="cc-n", title="T", notifications=[n])
+        json_bytes = adapter.dump_json(original)
+        restored = adapter.validate_json(json_bytes)
+        assert isinstance(restored, ClaudeCodeSession)
+        assert len(restored.notifications) == 1
+        assert restored.notifications[0].title == "Alert"
+        assert restored.notifications[0].body == "Details"
+        assert restored.notifications[0].url == "/s1"
+
+    def test_backward_compat_no_notifications_field(self) -> None:
+        """Existing ClaudeCodeSession JSON without notifications loads with empty list."""
+        from pydantic import TypeAdapter
+
+        adapter = TypeAdapter(Session)
+        data = {
+            "session_id": "cc-old",
+            "title": "Old session",
+            "session_type": "claude_code",
+        }
+        session = adapter.validate_python(data)
+        assert isinstance(session, ClaudeCodeSession)
+        assert session.notifications == []
+
+    def test_pending_question_returns_none_when_no_notifications(self) -> None:
+        """pending_question returns None when notifications list is empty."""
+        session = ClaudeCodeSession(session_id="s1", title="T")
+        assert session.pending_question is None
+
+    def test_pending_question_returns_last_notification(self) -> None:
+        """pending_question returns the last notification."""
+        n1 = Notification(title="First")
+        n2 = Notification(title="Last")
+        session = ClaudeCodeSession(session_id="s1", title="T", notifications=[n1, n2])
+        pq = session.pending_question
+        assert pq is not None
+        assert pq.title == "Last"
+
+
 class TestClaudeCodeSessionState(unittest.TestCase):
     """Tests for ClaudeCodeSession.state lifecycle behavior."""
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1344,6 +1344,35 @@ class TestClaudeCodeSession(unittest.TestCase):
         ids = [s.session_id for s in sessions]
         assert "cc-list" in ids
 
+    def test_add_notification_on_claude_code_session(self) -> None:
+        """add_notification() works on a ClaudeCodeSession."""
+        from zing_ai.server.models import ClaudeCodeSession
+
+        self.manager.create_claude_code_session(session_id="cc-notif", title="Notif Test")
+        notif = self.manager.add_notification("cc-notif", "Alert", body="Details", url="/cc-notif")
+        session = self.manager.get_session("cc-notif")
+        assert session is not None
+        assert isinstance(session, ClaudeCodeSession)
+        assert len(session.notifications) == 1
+        assert session.notifications[0].id == notif.id
+        assert session.notifications[0].title == "Alert"
+        assert session.notifications[0].body == "Details"
+        assert session.notifications[0].url == "/cc-notif"
+
+    def test_add_notification_on_claude_code_session_fires_event(self) -> None:
+        """add_notification() on ClaudeCodeSession fires a listener event."""
+        self.manager.create_claude_code_session(session_id="cc-evt", title="Event Test")
+        events: list[tuple[str, str]] = []
+        self.manager.add_listener(lambda et, sid: events.append((et, sid)))
+
+        notif = self.manager.add_notification("cc-evt", "Event Alert")
+        matching = [
+            (et, sid)
+            for et, sid in events
+            if et == f"notification_added:{notif.id}" and sid == "cc-evt"
+        ]
+        assert len(matching) == 1
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds a proactive attention management system to the Command Center that surfaces all sessions needing user input — Zing findings to review, Claude Code sessions waiting for answers, and plan questions — into a unified attention bar and slide-out review drawer.

Three integration points:
- **Attention bar** above the kanban board — collapsible list of pending actions sorted by wait time
- **Review drawer** — right-side 500px slide-out panel with session history, findings triage, and "Submit & Next" queue navigation
- **Card session strips** — timeline indicators on cards with sessions that open the drawer for history browsing

## What's in the diff

**Backend (Steps 1-3):**
- `models.py`: Added `answered_at` to `Notification`, `notifications` + `pending_question` to `ClaudeCodeSession`
- `sessions.py`: Removed `isinstance(ZingSession)` guard on `add_notification()`
- `app.py`: Wired `notification_added` events to fire `board_changed` for CC SSE clients
- `attention.py` (new): `AttentionItem` dataclass + `build_attention_queue()` function
- `routes_command_center.py`: `POST /session-question` endpoint (with tmux/terminal fallback lookup), `GET /drawer/{session_id}`, `render_attention_bar_fragment()`, `build_drawer_context()`

**Frontend (Steps 4-7):**
- `attention_bar.html` (new): Server-rendered attention items with type icons, step badges, action buttons
- `review_drawer.html` (new): Full drawer with step history, per-finding response rows, timeline bar, triage buttons, "Submit & Next" footer
- `drawer_attach.html` (new): Attach mode with blue hero card for Claude Code questions
- `kanban_card.html`: Blue attach strip for pending questions, session history strip with mini phase bar
- `command_center.html`: Drawer container + vanilla JS (openReviewDrawer, submitAndNext, skipToNext, nav arrows, ESC close)
- CSS: ~1,060 lines covering attention bar, drawer, card strips, board dimming, all matching the prototype

**Install flow (Step 8):**
- `hooks/notify-zing.sh` (new): Bundled bash hook for `PreToolUse` AskUserQuestion → server POST
- `installer.py`: `install_claude_hooks()` copies hook script + merges `PreToolUse` config into `settings.json`

**Code review fixes (build-audit):**
- Fixed critical naive/aware datetime crash in `build_attention_queue`
- Fixed drawer passing `session_id` instead of `terminal_session` to attach endpoint
- Wired up `build_session_phases()` to card template context (was dead code)
- Switched attention bar collapse to Datastar signal (preserves state across SSE patches)
- Added `isinstance(ClaudeCodeSession)` guard on session-question endpoint
- Optimized: snapshot `list_sessions()` once per SSE board_changed event
- Added logging on drawer/question 404 error paths

## Test plan

- [x] 716 unit tests pass (16 new attention queue tests, 7 new installer hook tests, model/session test additions)
- [x] 86 Playwright UI tests pass (including all kebab menu tests after fixing merge error)
- [x] pyright, ruff, pyleft all pass
- [ ] Manual: Open command center with active Zing sessions → verify attention bar shows pending actions
- [ ] Manual: Click "Review" on attention item → verify drawer opens with findings
- [ ] Manual: Click "Attach" on Claude Code question → verify terminal modal opens
- [ ] Manual: Collapse attention bar → verify it stays collapsed across SSE refreshes

---

🤖 Created with [Zing](https://github.com/Farmer-Pete/Zing)